### PR TITLE
Fix c-scanner regex pattern

### DIFF
--- a/v2/tools/types/cpp.jam
+++ b/v2/tools/types/cpp.jam
@@ -30,7 +30,7 @@ class c-scanner : scanner
 
     rule pattern ( )
     {
-        return "#[ \t]*include[ ]*(<(.*)>|\"(.*)\")" ;
+        return "#[ \t]*include[ \t]*(<(.*)>|\"(.*)\")" ;
     }
 
     rule process ( target : matches * : binding )


### PR DESCRIPTION
The c-scanner regex pattern doesn't take care of tab, which is placed between `include` and `<>` `""`.
