### PR TITLE
Extend version-countdown to also support Python 3.1-3.4.

### DIFF
--- a/v2/tools/python.jam
+++ b/v2/tools/python.jam
@@ -388,12 +388,12 @@ local rule split-version ( version )
 }
 
 
-# Build a list of versions from 3.0 down to 1.5. Because bjam can not enumerate
+# Build a list of versions from 3.4 down to 1.5. Because bjam can not enumerate
 # registry sub-keys, we have no way of finding a version with a 2-digit minor
 # version, e.g. 2.10 -- let us hope that never happens.
 #
 .version-countdown = ;
-for local v in [ numbers.range 15 30 ]
+for local v in [ numbers.range 15 34 ]
 {
     .version-countdown = [ SUBST $(v) (.)(.*) $1.$2 ] $(.version-countdown) ;
 }


### PR DESCRIPTION
As of today, Boost Python does not build against Python >3.0 on Windows. This is because newer installations are not detected by the windows-installed-pythons rule. The reason for this is because the rule only looks for Python 1.5-3.0, and not for newer versions.

This patch extends version-countdown used by windows-installed-pythons to also search for Python 3.1-3.4. This fixes the problem of building Boost Python against Python 3.3 on computer.
