### PR TITLE
Avoid slow MSVC setup scripts. Closes ticket #234.

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -509,10 +509,9 @@ if [ os.name ] in NT
 
     actions manifest
     {
-        $(.MT.SETUP)
-        if exist "$(<[1]).manifest" (
-            $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);1"
-        )
+        if not exist "$(<[1]).manifest" goto :skip
+        $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);1"
+        :skip
     }
 
     actions link.dll bind DEF_FILE LIBRARIES_MENTIONED_BY_FILE
@@ -523,10 +522,9 @@ if [ os.name ] in NT
 
     actions manifest.dll
     {
-        $(.MT.SETUP)
-        if exist "$(<[1]).manifest" (
-            $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);2"
-        )
+        if not exist "$(<[1]).manifest" goto :skip
+        $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);2"
+        :skip
     }
 }
 else
@@ -1014,9 +1012,7 @@ local rule configure-really ( version ? : options * )
             toolset.flags msvc.archive .LD  $(cpu-conditions) : $(setup-$(c))$(linker) /lib /NOLOGO  ;
             toolset.flags msvc.compile .IDL $(cpu-conditions) : $(setup-$(c))$(idl-compiler) ;
             toolset.flags msvc.compile .MC  $(cpu-conditions) : $(setup-$(c))$(mc-compiler) ;
-
-            toolset.flags msvc.link .MT.SETUP : $(setup-$(c)) ;
-            toolset.flags msvc.link .MT $(cpu-conditions) : $(manifest-tool) -nologo ;
+            toolset.flags msvc.link    .MT  $(cpu-conditions) : $(setup-$(c))$(manifest-tool) -nologo ;
 
             if $(cc-filter)
             {


### PR DESCRIPTION
Since MSVC 10.0 compiler setup scripts became very slow. Avoid calling them on every build action by caching their environment changes.

Discussion: http://lists.boost.org/boost-build/2013/09/27000.php
Ticket: https://trac.lvk.cs.msu.su/boost.build/ticket/234
