### PR TITLE
pass BOOST_JAM_TOOLSET to calling script

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -513,11 +513,11 @@ set test=%test:"###=%
 set test=%test:###"=%
 set test=%test:###=%
 if "%test%" == "--update" goto Found_Update
-endlocal
+endlocal & set BOOST_JAM_TOOLSET=%BOOST_JAM_TOOLSET%
 shift
 if not "_%BJAM_UPDATE%_" == "_update_" goto Check_Update
 :Found_Update
-endlocal
+endlocal & set BOOST_JAM_TOOLSET=%BOOST_JAM_TOOLSET%
 set BJAM_UPDATE=update
 :Check_Update_End
 if "_%BJAM_UPDATE%_" == "_update_" (


### PR DESCRIPTION
A note in bootstrap.bat file mentioned that the toolset should really
be retrieved from build.bat, but the developer didn't know how.

The comment I'm referring to is here: https://github.com/boostorg/boost/blob/bd86bb8943e01c266e5c2882706f8301e9a752b7/bootstrap.bat#L34

I'm not sure if that's still relevant or not, since I noticed the boostrap.bat file in this module of the project doesn't work the same.
