### PR TITLE
Adding feature to turn on/off test execution after compilation.

### DIFF
--- a/src/tools/testing.jam
+++ b/src/tools/testing.jam
@@ -1,5 +1,6 @@
 # Copyright 2005 Dave Abrahams
 # Copyright 2002, 2003, 2004, 2005, 2006 Vladimir Prus
+# Copyright (c) 2014 Microsoft Corporation
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 


### PR DESCRIPTION
Added a new feature called testing.execute that can be used to control whether or not a test is actually run after compilation.

Changed to be called testing.execute based on feedback. Broken out of previous pull request: https://github.com/boostorg/build/pull/9
