### PR TITLE
Add support for MSVC 14

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -28,7 +28,7 @@ ECHO ### You can specify the toolset as the argument, i.e.:
 ECHO ###     .\build.bat msvc
 ECHO ###
 ECHO ### Toolsets supported by this script are: borland, como, gcc, gcc-nocygwin,
-ECHO ###     intel-win32, metrowerks, mingw, msvc, vc7, vc8, vc9, vc10, vc11, vc12
+ECHO ###     intel-win32, metrowerks, mingw, msvc, vc7, vc8, vc9, vc10, vc11, vc12, vc14
 ECHO ###
 call :Set_Error
 endlocal
@@ -100,6 +100,16 @@ call :Clear_Error
 call :Test_Empty %ProgramFiles%
 if not errorlevel 1 set ProgramFiles=C:\Program Files
 
+call :Clear_Error
+if NOT "_%VS140COMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET=vc14"
+    set "BOOST_JAM_TOOLSET_ROOT=%VS140COMNTOOLS%..\..\VC\"
+    goto :eof)
+call :Clear_Error
+if EXIST "%ProgramFiles%\Microsoft Visual Studio 14.0\VC\VCVARSALL.BAT" (
+    set "BOOST_JAM_TOOLSET=vc14"
+    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFiles%\Microsoft Visual Studio 14.0\VC\"
+    goto :eof)
 call :Clear_Error
 if NOT "_%VS120COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET=vc12"
@@ -421,6 +431,21 @@ set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
 set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
 set "_known_=1"
 :Skip_VC12
+if NOT "_%BOOST_JAM_TOOLSET%_" == "_vc14_" goto Skip_VC14
+if NOT "_%VS140COMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET_ROOT=%VS140COMNTOOLS%..\..\VC\"
+    )
+if "_%VCINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%VCVARSALL.BAT" %BOOST_JAM_ARGS%
+if NOT "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
+    if "_%VCINSTALLDIR%_" == "__" (
+        set "PATH=%BOOST_JAM_TOOLSET_ROOT%bin;%PATH%"
+        ) )
+set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
+set "BOOST_JAM_OPT_JAM=/Febootstrap\jam0"
+set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
+set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
+set "_known_=1"
+:Skip_VC14
 if NOT "_%BOOST_JAM_TOOLSET%_" == "_borland_" goto Skip_BORLAND
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     call :Test_Path bcc32.exe )

--- a/src/engine/build.jam
+++ b/src/engine/build.jam
@@ -371,13 +371,21 @@ toolset vc10 cl : /Fe /Fe /Fd /Fo : -D
     [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]
     -I$(--python-include) -I$(--extra-include)
     : kernel32.lib advapi32.lib user32.lib $(--python-lib[1]) ;
+## Microsoft Visual C++ 2012
 toolset vc11 cl : /Fe /Fe /Fd /Fo : -D
     : /nologo
     [ opt --release : /GL /MT /O2 /Ob2 /Gy /GF /GA /wd4996 ]
     [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]
     -I$(--python-include) -I$(--extra-include)
     : kernel32.lib advapi32.lib user32.lib $(--python-lib[1]) ;
+## Microsoft Visual C++ 2013
 toolset vc12 cl : /Fe /Fe /Fd /Fo : -D
+    : /nologo
+    [ opt --release : /GL /MT /O2 /Ob2 /Gy /GF /GA /wd4996 ]
+    [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]
+    -I$(--python-include) -I$(--extra-include)
+    : kernel32.lib advapi32.lib user32.lib $(--python-lib[1]) ;
+toolset vc14 cl : /Fe /Fe /Fd /Fo : -D
     : /nologo
     [ opt --release : /GL /MT /O2 /Ob2 /Gy /GF /GA /wd4996 ]
     [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -749,7 +749,11 @@ local rule configure-really ( version ? : options * )
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if [ MATCH "(Microsoft Visual Studio 12)" : $(command) ]
+            if [ MATCH "(Microsoft Visual Studio 14)" : $(command) ]
+            {
+                version = 14.0 ;
+            }
+            else if [ MATCH "(Microsoft Visual Studio 12)" : $(command) ]
             {
                 version = 12.0 ;
             }
@@ -1391,7 +1395,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 
 
 # Known toolset versions, in order of preference.
-.known-versions = 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
+.known-versions = 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
     7.1toolkit 7.0 6.0 ;
 
 # Version aliases.
@@ -1403,6 +1407,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 .version-alias-10 = 10.0 ;
 .version-alias-11 = 11.0 ;
 .version-alias-12 = 12.0 ;
+.version-alias-14 = 14.0 ;
 
 # Names of registry keys containing the Visual C++ installation path (relative
 # to "HKEY_LOCAL_MACHINE\SOFTWARE\\Microsoft").
@@ -1417,6 +1422,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 .version-10.0express-reg = "VCExpress\\10.0\\Setup\\VC" ;
 .version-11.0-reg = "VisualStudio\\11.0\\Setup\\VC" ;
 .version-12.0-reg = "VisualStudio\\12.0\\Setup\\VC" ;
+.version-14.0-reg = "VisualStudio\\14.0\\Setup\\VC" ;
 
 # Visual C++ Toolkit 2003 does not store its installation path in the registry.
 # The environment variable 'VCToolkitInstallDir' and the default installation

--- a/src/tools/msvc.py
+++ b/src/tools/msvc.py
@@ -676,7 +676,9 @@ def configure_really(version=None, options=[]):
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if re.search("Microsoft Visual Studio 12", command):
+            if re.search("Microsoft Visual Studio 14", command):
+                version = '14.0'
+            elif re.search("Microsoft Visual Studio 12", command):
                 version = '12.0'
             elif re.search("Microsoft Visual Studio 11", command):
                 version = '11.0'
@@ -1189,7 +1191,7 @@ __cpu_type_itanium2 = ['itanium2', 'mckinley']
 
 
 # Known toolset versions, in order of preference.
-_known_versions = ['12.0', '11.0', '10.0', '10.0express', '9.0', '9.0express', '8.0', '8.0express', '7.1', '7.1toolkit', '7.0', '6.0']
+_known_versions = ['14.0', '12.0', '11.0', '10.0', '10.0express', '9.0', '9.0express', '8.0', '8.0express', '7.1', '7.1toolkit', '7.0', '6.0']
 
 # Version aliases.
 __version_alias_6 = '6.0'
@@ -1200,6 +1202,7 @@ __version_alias_9 = '9.0'
 __version_alias_10 = '10.0'
 __version_alias_11 = '11.0'
 __version_alias_12 = '12.0'
+__version_alias_14 = '14.0'
 
 # Names of registry keys containing the Visual C++ installation path (relative
 # to "HKEY_LOCAL_MACHINE\SOFTWARE\\Microsoft").
@@ -1214,6 +1217,7 @@ __version_10_0_reg = "VisualStudio\\10.0\\Setup\\VC"
 __version_10_0express_reg = "VCExpress\\10.0\\Setup\\VC"
 __version_11_0_reg = "VisualStudio\\11.0\\Setup\\VC"
 __version_12_0_reg = "VisualStudio\\12.0\\Setup\\VC"
+__version_14_0_reg = "VisualStudio\\14.0\\Setup\\VC"
 
 # Visual C++ Toolkit 2003 does not store its installation path in the registry.
 # The environment variable 'VCToolkitInstallDir' and the default installation


### PR DESCRIPTION
Tested by running bootstrap in cmd.exe with no other Visual Studio versions installed, as that is not yet supported in CTP1.
