### PR TITLE
Make find-replace unconditional, so that an empty replace will also work...

### DIFF
--- a/src/build/property.jam
+++ b/src/build/property.jam
@@ -766,10 +766,7 @@ class property-map
             errors.error "Ambiguous key $(properties:J= :E=)" ;
         }
         local original = $($(best)[1]) ;
-        if $(value)
-        {
-            $(best) = $(value) $($(best)[2-]) ;
-        }
+        $(best) = $(value) $($(best)[2-]) ;
         return $(original) ;
     }
 }


### PR DESCRIPTION
....

I needed this to make
type.change-generated-target-prefix SHARED_LIB : <toolset>gcc <target-os>windows : "" ;
work.
