### PR TITLE
Fixing build break with Visual Studio if phone scripts aren't installed with VS 2012/2013

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1054,12 +1054,11 @@ local rule configure-really ( version ? : options * )
                 {
                     phone-directory = [ path.native [ path.join $(phone-parent) WP81 ] ] ;
                 }
+                global-setup-phone ?= [ locate-default-setup $(phone-directory) : $(phone-parent) : vcvarsphoneall.bat ] ;
                 
-                # If phone-directory is not set then this VS version doesn't support Windows Phone.
-                if $(phone-directory)-is-defined
+                # If can't locate default phone setup script then this VS version doesn't support Windows Phone.
+                if $(global-setup-phone)-is-defined
                 {
-                    global-setup-phone ?= [ locate-default-setup $(phone-directory) : $(phone-parent) : vcvarsphoneall.bat ] ;
-                
                     # i386 CPU is for the Windows Phone emulator in Visual Studio.
                     local phone-cpu = i386 arm ;
                     for local c in $(phone-cpu)


### PR DESCRIPTION
Fixes a late issue discovered that can cause build issues if Visual Studio 2012 or 2013 doesn't actually contain the Windows Phone setup scripts.

This was caused from pull request https://github.com/boostorg/build/pull/14. I've tested now on a machine without the phone setup scripts for Visual Studio 2012 and 2013.
