### PR TITLE
Use msvc setup script feature with intel compiler

### DIFF
--- a/src/tools/intel-win.jam
+++ b/src/tools/intel-win.jam
@@ -356,11 +356,7 @@ local rule configure-really ( version ? : command * : options * : compatibility 
         compatibility = vc7.1 ;
     }
 
-    # configure-version-specific chokes now on msvc version 12 it needs 12.0
-    if $(msvc-version) >= 12
-    {
-        msvc-version = "$(msvc-version).0" ;
-    }
+    msvc-version = [ msvc.resolve-possible-msvc-version-alias $(msvc-version) ] ;
     msvc.configure-version-specific intel-win :  $(msvc-version) : $(condition) ;
 }
 

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -315,6 +315,15 @@ rule register-toolset ( )
     }
 }
 
+rule resolve-possible-msvc-version-alias ( version )
+{
+    if $(.version-alias-$(version))
+    {
+        version = $(.version-alias-$(version)) ;
+    }
+    return $(version) ;
+}
+
 
 # Declare action for creating static libraries. If library exists, remove it
 # before adding files. See
@@ -832,10 +841,7 @@ local rule configure-really ( version ? : options * )
     }
 
     # Version alias -> real version number.
-    if $(.version-alias-$(version))
-    {
-        version = $(.version-alias-$(version)) ;
-    }
+    version = [ resolve-possible-msvc-version-alias $(version) ] ;
 
     # Check whether the selected configuration is already in use.
     if $(version) in [ $(.versions).used ]


### PR DESCRIPTION
It reuses the recently added feature to cache the msvc setup batch files.
It also fixes the breakage with intel compilerr and msvc 12.0 due new windows store functionality.
