### PR TITLE
Ipo/LTO Whole Program Optimization

### DIFF
--- a/src/tools/builtin.jam
+++ b/src/tools/builtin.jam
@@ -115,6 +115,8 @@ feature.feature inlining           : off on full     : propagated ;
 feature.feature threading          : single multi    : propagated ;
 feature.feature rtti               : on off          : propagated ;
 feature.feature exception-handling : on off          : propagated ;
+feature.feature link-time-optimization : off on : propagated ;
+feature.feature whole-program-optimization : off on : incidental propagated ;
 
 # Whether there is support for asynchronous EH (e.g. catching SEGVs).
 feature.feature asynch-exceptions  : off on          : propagated ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -385,6 +385,10 @@ toolset.flags gcc.compile OPTIONS <profiling>on : -pg ;
 toolset.flags gcc.compile.c++ OPTIONS <rtti>off : -fno-rtti ;
 toolset.flags gcc.compile.c++ OPTIONS <exception-handling>off : -fno-exceptions ;
 
+toolset.flags gcc.compile OPTIONS <whole-program-optimization>on : -flto ;
+toolset.flags gcc.link OPTIONS <link-time-optimization>on : -flto ;
+
+
 rule setup-fpic ( targets * : sources * : properties * )
 {
     local link = [ feature.get-values link : $(properties) ] ;

--- a/src/tools/intel-win.jam
+++ b/src/tools/intel-win.jam
@@ -347,6 +347,8 @@ local rule configure-really ( version ? : command * : options * : compatibility 
     # happy when compiler produces not the file it was asked for.
     # The option below stops this behaviour.
     toolset.flags intel-win CFLAGS : -Qpchi- ;
+    toolset.flags intel-win.compile CFLAGS <whole-program-optimization>on : /Qipo ;
+    toolset.flags intel-win.link LINKFLAGS <link-time-optimization>on : /qipo ;
 
     if ! $(compatibility)
     {

--- a/src/tools/intel-win.jam
+++ b/src/tools/intel-win.jam
@@ -20,7 +20,7 @@ import path ;
 feature.extend-subfeature toolset intel : platform : win ;
 
 toolset.inherit-generators intel-win <toolset>intel <toolset-intel:platform>win : msvc ;
-toolset.inherit-flags intel-win : msvc : : YLOPTION ;
+toolset.inherit-flags intel-win : msvc : <whole-program-optimization>on <link-time-optimization>on : YLOPTION  ;
 toolset.inherit-rules intel-win : msvc ;
 
 # Override default do-nothing generators.

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -276,6 +276,10 @@ rule configure-version-specific ( toolset : version : conditions )
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-ia64)  : /MACHINE:IA64 ;
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-arm)   : /MACHINE:ARM ;
 
+        toolset.flags $(toolset).compile CFLAGS $(conditions)/<whole-program-optimization>on : /GL ;
+        toolset.flags $(toolset).link LINKFLAGS $(conditions)/<link-time-optimization>on : /LTCG ;
+
+
         # Make sure that manifest will be generated even if there is no
         # dependencies to put there.
         toolset.flags $(toolset).link LINKFLAGS $(conditions) : /MANIFEST ;

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -276,10 +276,6 @@ rule configure-version-specific ( toolset : version : conditions )
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-ia64)  : /MACHINE:IA64 ;
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-arm)   : /MACHINE:ARM ;
 
-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<whole-program-optimization>on : /GL ;
-        toolset.flags $(toolset).link LINKFLAGS $(conditions)/<link-time-optimization>on : /LTCG ;
-
-
         # Make sure that manifest will be generated even if there is no
         # dependencies to put there.
         toolset.flags $(toolset).link LINKFLAGS $(conditions) : /MANIFEST ;
@@ -1350,6 +1346,8 @@ local rule register-toolset-really ( )
     toolset.flags msvc.compile CFLAGS <optimization>speed : /O2 ;
     toolset.flags msvc.compile CFLAGS <optimization>space : /O1 ;
 
+    toolset.flags msvc.compile CFLAGS <whole-program-optimization>on : /GL ;
+
     toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium) : /G1 ;
     toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium2) : /G2 ;
 
@@ -1411,6 +1409,8 @@ local rule register-toolset-really ( )
         # The linker disables the default optimizations when using /DEBUG so we
         # have to enable them manually for release builds with debug symbols.
         toolset.flags msvc LINKFLAGS <debug-symbols>on/<runtime-debugging>off : /OPT:REF,ICF ;
+        
+        toolset.flags msvc.link LINKFLAGS <link-time-optimization>on : /LTCG ;
 
         toolset.flags msvc LINKFLAGS <user-interface>console : /subsystem:console ;
         toolset.flags msvc LINKFLAGS <user-interface>gui : /subsystem:windows ;


### PR DESCRIPTION
Added whole-program-optimization flags for msvc, intel-win and gcc. Splitted in two features to allow compilation of some source files without whole-program-optimization.
