### PR TITLE
Fixed compatibility issues for 64-bit AIX

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -790,12 +790,16 @@ rule init-link-flags ( toolset linker condition )
         # searched during load-time. Note that the AIX linker does not have an
         # -soname equivalent, this is as close as it gets.
         #
+        # The -bbigtoc option instrcuts the linker to create a TOC bigger than 64k.
+        # This is neccesary for some submodules such as math, but it does make running
+        # the tests a tad slower.
+        #
         # The above options are definately for AIX 5.x, and most likely also for
         # AIX 4.x and AIX 6.x. For details about the AIX linker see:
         # http://download.boulder.ibm.com/ibmdl/pub/software/dw/aix/es-aix_ll.pdf
         #
 
-        toolset.flags $(toolset).link OPTIONS : -Wl,-brtl -Wl,-bnoipath
+        toolset.flags $(toolset).link OPTIONS : -Wl,-brtl -Wl,-bnoipath -Wl,-bbigtoc
             : unchecked ;
 
     case darwin :
@@ -1182,4 +1186,4 @@ cpu-flags gcc OPTIONS : power : rios2 : -mcpu=rios2 ;
 cpu-flags gcc OPTIONS : power : rsc : -mcpu=rsc ;
 cpu-flags gcc OPTIONS : power : rs64a : -mcpu=rs64 ;
 # AIX variant of RS/6000 & PowerPC
-toolset.flags gcc AROPTIONS <address-model>64/<target-os>aix : "-X 64" ;
+toolset.flags gcc AROPTIONS <address-model>64/<target-os>aix : "-X64" ;

--- a/src/tools/gcc.py
+++ b/src/tools/gcc.py
@@ -830,4 +830,4 @@ cpu_flags('gcc', 'OPTIONS', 'power', 'rs64a', ['-mcpu=rs64'])
 # AIX variant of RS/6000 & PowerPC
 flags('gcc', 'OPTIONS', ['<architecture>power/<address-model>32/<target-os>aix'], ['-maix32'])
 flags('gcc', 'OPTIONS', ['<architecture>power/<address-model>64/<target-os>aix'], ['-maix64'])
-flags('gcc', 'AROPTIONS', ['<architecture>power/<address-model>64/<target-os>aix'], ['-X 64'])
+flags('gcc', 'AROPTIONS', ['<architecture>power/<address-model>64/<target-os>aix'], ['-X64'])


### PR DESCRIPTION
I added bbigtoc flag because I was getting some TOC overflow errors in the some of the submodules, including math, and I wanted to fix the problem in a more permanent way that did not involve the user adding that flag to their user-config.jam. The tests might run slower, but I don't think this is really an issue.

The archiver that boost chooses for AIX to use is not its native archiver, it is the linux one. This in itself is not a problem except for the fact that there is a typo in the last line where there is an extra space that causes a syntax error.
