### PR TITLE
msvc: allow dlls without lib file

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1306,7 +1306,10 @@ local rule register-toolset-really ( )
             OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB : EXE : <toolset>msvc ] ;
         generators.register [ new msvc-linking-generator msvc.link.dll :
             OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB : SHARED_LIB IMPORT_LIB :
-            <toolset>msvc ] ;
+            <toolset>msvc <suppress-import-lib>false ] ;
+        generators.register [ new msvc-linking-generator msvc.link.dll :
+            OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB : SHARED_LIB :
+            <toolset>msvc <suppress-import-lib>true ] ;
 
         generators.register-archiver msvc.archive : OBJ : STATIC_LIB : <toolset>msvc ;
         generators.register-c-compiler msvc.compile.c++ : CPP : OBJ : <toolset>msvc ;

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1424,6 +1424,8 @@ local rule register-toolset-really ( )
         toolset.flags msvc.link FINDLIBS_SA <find-shared-library> ;
         toolset.flags msvc.link LIBRARY_OPTION <toolset>msvc : "" : unchecked ;
         toolset.flags msvc.link LIBRARIES_MENTIONED_BY_FILE : <library-file> ;
+        
+        toolset.flags msvc.link.dll LINKFLAGS <suppress-import-lib>true : /NOENTRY ;
     }
 
     toolset.flags msvc.archive AROPTIONS <archiveflags> ;


### PR DESCRIPTION
On Windows it is possible to create a dll consisting only of a resource (message) file which is used for the eventlog. Because it doesn't export any function the msvc linker doesn't create a lib file. Due to that boost build always thinks that the dll needs to be build. i have registered the generator twice with the feature suppress-import-lib (there is no use/doc of it) and only generate the IMPORT_LIB target for one. i haven't figured out another way to achieve that.
What is missing that /NOENTRY needs to be passed to the linker. The pull request is to gain ideas/comments how to fully implement the feature for dlls without any exports.
regards,
bernhard
