### PR TITLE
Fix typos in tutorial "Conditions and alternatives".

### DIFF
--- a/doc/src/overview.xml
+++ b/doc/src/overview.xml
@@ -1194,14 +1194,14 @@ obj main : main.cpp : &lt;optimization&gt;off ;
         release mode.
 <programlisting>
 lib network : network.cpp
-    : <emphasis role="bold">&lt;link&gt;shared:&lt;define&gt;NEWORK_LIB_SHARED</emphasis>
+    : <emphasis role="bold">&lt;link&gt;shared:&lt;define&gt;NETWORK_LIB_SHARED</emphasis>
      &lt;variant&gt;release:&lt;define&gt;EXTRA_FAST
     ;
 </programlisting>
 
         In the example above, whenever <filename>network</filename> is
         built with <code>&lt;link&gt;shared</code>,
-        <code>&lt;define&gt;NEWORK_LIB_SHARED</code> will be in its
+        <code>&lt;define&gt;NETWORK_LIB_SHARED</code> will be in its
         properties, too.
         </para>
 

--- a/doc/src/tutorial.xml
+++ b/doc/src/tutorial.xml
@@ -556,12 +556,12 @@ exe app : app.cpp core ;</programlisting>
 
       <programlisting language="jam">
 lib network : network.cpp
-    : <emphasis role="bold">&lt;link&gt;shared:&lt;define&gt;NEWORK_LIB_SHARED</emphasis>
+    : <emphasis role="bold">&lt;link&gt;shared:&lt;define&gt;NETWORK_LIB_SHARED</emphasis>
      &lt;variant&gt;release:&lt;define&gt;EXTRA_FAST
     ;</programlisting>
 
       In the example above, whenever <filename>network</filename> is built with
-      <code language="jam">&lt;link&gt;shared</code>, <code language="jam">&lt;define&gt;NEWORK_LIB_SHARED
+      <code language="jam">&lt;link&gt;shared</code>, <code language="jam">&lt;define&gt;NETWORK_LIB_SHARED
       </code> will be in its properties, too. Also, whenever its release variant
       is built, <code>&lt;define&gt;EXTRA_FAST</code> will appear in its
       properties.


### PR DESCRIPTION
Fixed typo NEWORK_LIB_SHARED -> NETWORK_LIB_SHARED.
