### PR TITLE
Fixed python 2to3 translation

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -1057,14 +1057,14 @@ IMPORT python : python-extension : : python-extension ;
 
 rule py2to3
 {
-    common.copy $(>) $(<) ;
+    common.copy $(<) : $(>) ;
     2to3 $(<) ;
 }
 
 actions 2to3
 {
-    2to3 -wn "$(<)"
-    2to3 -dwn "$(<)"
+    2to3 -wn --no-diffs "$(<)"
+    2to3 -dwn --no-diffs "$(<)"
 }
 
 


### PR DESCRIPTION
I noticed that the Boost.Python tests would not run with Python 3.x. This fixes the issue.
I also added "--no-diffs" to silence the 2to3 diff output which is too verbose by default.
