### PR TITLE
Visual studio support for <variant> property

### DIFF
--- a/src/tools/builtin.jam
+++ b/src/tools/builtin.jam
@@ -389,9 +389,16 @@ rule variant ( name            # Name of the variant
 IMPORT $(__name__) : variant : : variant ;
 
 
+# In order to be used withing Visusl Studio scripting subsystem and provide
+# compatability with $(Configuration) macro variable add configuration
+# with different capitalization: Debug and Release.
 variant debug   : <optimization>off <debug-symbols>on <inlining>off
                   <runtime-debugging>on ;
+variant Debug   : <optimization>off <debug-symbols>on <inlining>off
+                  <runtime-debugging>on ;
 variant release : <optimization>speed <debug-symbols>off <inlining>full
+                  <runtime-debugging>off <define>NDEBUG ;
+variant Release : <optimization>speed <debug-symbols>off <inlining>full
                   <runtime-debugging>off <define>NDEBUG ;
 variant profile : release : <profiling>on <debug-symbols>on ;
 


### PR DESCRIPTION
Normally "variant" is either 'debug' or 'release' but VS only provides 'Debug' and 'Release'. I've added rule to support this capitalization as well so boost build could integrate better into MSVC scripting environment. This will provide 50% reduction in maintenance effort (no need to maintain two sets of project files).
