### PR TITLE
Add support for Intel 15, fix Glob Bug, and compiler path selection bug.

### DIFF
--- a/src/tools/intel-win.jam
+++ b/src/tools/intel-win.jam
@@ -176,7 +176,7 @@ local rule configure-really ( version ? : command * : options * : compatibility 
     }
 
     local setup ;
-    setup = [ GLOB $(root) : iclvars_*.bat ] ;
+    setup = [ path.glob $(root) : iclvars_*.bat ] ;
     if ! $(setup)
     {
        setup = [ path.join $(root) "iclvars.bat" ] ;
@@ -201,7 +201,14 @@ local rule configure-really ( version ? : command * : options * : compatibility 
         {
             errors.error "Don't know what parameter to pass for vc version ( $(compatibility) )" ;
         }
-        if [ MATCH ^(AMD64) : [ os.environ PROCESSOR_ARCHITECTURE ] ]
+        # There are two possible paths for the 64-bit intel compiler,
+        # one for the IA32-Intel64 cross compiler, and one for the native
+        # 64 bit compiler. We prefer the latter one if it's installed,
+        # and don't rely on whether the OS reports whether we're 64 or 32 bit
+        # as that really only tells us which subsystem bjam is running in:
+        #
+        local intel64_path = [ path.join $(root) intel64 ] ;
+        if [ path.glob $(intel64_path) : icl.exe ]
         {
             target_types = ia32 intel64 ;
         }
@@ -466,6 +473,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 .iclvars-12.1-supported-vcs = "10.0 9.0 8.0" ;
 .iclvars-13.0-supported-vcs = "11.0 10.0 9.0" ;
 .iclvars-14.0-supported-vcs = "12.0 11.0 10.0 9.0" ;
+.iclvars-15.0-supported-vcs = "12.0 11.0 10.0 9.0" ;
 .iclvars-version-alias-vc12 = vs2013 ;
 .iclvars-version-alias-vc11 = vs2012 ;
 .iclvars-version-alias-vc10 = vs2010 ;


### PR DESCRIPTION
This patch fixes 3 issues:
- Adds support for Intel-15 so MSVC version can be auto-selected.
- Changes GLOB to path.glob as for some reason the GLOB rule always fails when used in this context (discovered when testing this patch).
- Changes selection logic for target-types variable - previous code used the value of PROCESSOR_ARCHITECTURE to detect this, but that appears to only tell you which sub-system bjam is running in.  For example on my system bjam is a 32-bit app (default for an msvc build), but I only have the Intel 64-bit compiler installed (under /intel64/).  New logic checks whether the intel64 compiler exists and uses that if it is - Intel's installer won't install this on 32 bit platforms in which case the glob fails and things fall back to the ia32-intel64 cross compiler when address-model=64 is specified.
