### PR TITLE
Preserve order of properties in PropertySet

### DIFF
--- a/src/build/property_set.py
+++ b/src/build/property_set.py
@@ -41,7 +41,7 @@ def create (raw_properties = []):
     else:
         x = [property.create_from_string(ps) for ps in raw_properties]
     x.sort()
-    x = unique (x)
+    x = unique(x, stable=True)
 
     # FIXME: can we do better, e.g. by directly computing
     # hash value of the list?


### PR DESCRIPTION
From what I've been told, the order of includes and defines (from BoostBuild's perspective) should not matter and if it does, the `<include>a&&b` mechanism should be used.

This change was created in the spirit of preserving backwards compatibility and causes the command output in Python to match the command output in Jam.

**Note**: I've tested this change using the `timeit` module and preserving the order can cause construction of the new list to be an **order of magnitude slower**, however, on small property sets, this will still be negligible.
