### PR TITLE
Return valid exit code from Windows batch scripts.

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -47,3 +47,4 @@ ECHO.
 goto :end
 
 :end
+exit /b %ERRORLEVEL%

--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -613,3 +613,4 @@ goto Set_Args
 :Skip_Jam
 
 :Finish
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
Technique used for setting Windows batch script exit codes in Boost.Build worked
correctly when the script is called from a Windows shell process and then checked
from inside that process. However, when run from a temporary shell process that
needs to terminate after running the script, such a process would always return
exit code 0.

This prevented anyone automating those scripts from detecting their success/
failure status by using their exit code without adding an additional batch script
layer.

For example, consider the following two script files:

ret666.cmd: `exit /b 666`
wrapper.cmd: `call ret666.cmd`

They both 'should return the value 666' and when run directly from a `cmd.exe`
console indeed both do (they set the shell process's `ERRORLEVEL` environment
variable to 666). However, when run using `cmd /c <script-name>` running
`ret666.cmd` causes the temporary `cmd.exe` process to exit with exit code 666,
while running `wrapper.cmd` causes it to exit with exit code 0.
