### PR TITLE
Detect the intel compiler in the environement when building bjam. 

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -70,8 +70,8 @@ Guess_Toolset ()
     elif test_uname IRIX64 ; then BOOST_JAM_TOOLSET=mipspro
     elif test_uname OSF1 ; then BOOST_JAM_TOOLSET=tru64cxx
     elif test_uname QNX && test_path qcc ; then BOOST_JAM_TOOLSET=qcc
-    elif test_path icc ; then BOOST_JAM_TOOLSET=intel-linux
     elif test_path gcc ; then BOOST_JAM_TOOLSET=gcc
+    elif test_path icc ; then BOOST_JAM_TOOLSET=intel-linux
     elif test -r /opt/intel/cc/9.0/bin/iccvars.sh ; then
         BOOST_JAM_TOOLSET=intel-linux
         BOOST_JAM_TOOLSET_ROOT=/opt/intel/cc/9.0


### PR DESCRIPTION
The mentioned 'standard' path were quite old (9.0, last Intel compiler version is 15.x as on Oct 2014). 
Intel package organization changes quite often these days, so the environment seems like the best place to search

Kept the legacy detection though.
Build in 64 bit (needs to be specified, 64bit seems more common).
