### PR TITLE
Remove an option not supported by clang.

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -76,7 +76,7 @@ toolset.flags clang-linux.compile OPTIONS <optimization>space : -Os ;
 # note: clang silently ignores some of these inlining options
 toolset.flags clang-linux.compile OPTIONS <inlining>off  : -fno-inline ;
 toolset.flags clang-linux.compile OPTIONS <inlining>on   : -Wno-inline ;
-toolset.flags clang-linux.compile OPTIONS <inlining>full : -finline-functions -Wno-inline ;
+toolset.flags clang-linux.compile OPTIONS <inlining>full : -Wno-inline ;
 
 toolset.flags clang-linux.compile OPTIONS <warnings>off : -w ;
 toolset.flags clang-linux.compile OPTIONS <warnings>on  : -Wall ;


### PR DESCRIPTION
I'm not certain when, if ever, clang supported the flag. Certainly in 3.5 it produces a fairly ugly warning:

```
clang: warning: optimization flag '-finline-functions' is not supported
clang: warning: argument unused during compilation: '-finline-functions'
```

The 3.5 release notes state that clang is now warning about options it doesn't understand -- previously it was silently ignoring them. I think it might be better to just turn it off for 3.5 and later, but I only know how to do this for specific versions, not a condition like < 3.5.
