### PR TITLE
Develop mode type checking

### DIFF
--- a/src/build/alias.py
+++ b/src/build/alias.py
@@ -29,7 +29,7 @@ import targets
 import property_set
 from b2.manager import get_manager
 
-from b2.util import metatarget
+from b2.util import metatarget, is_iterable_typed
 
 class AliasTarget(targets.BasicTarget):
 
@@ -37,9 +37,17 @@ class AliasTarget(targets.BasicTarget):
         targets.BasicTarget.__init__(self, *args)
 
     def construct(self, name, source_targets, properties):
+        if __debug__:
+            from .virtual_target import VirtualTarget
+            assert isinstance(name, basestring)
+            assert is_iterable_typed(source_targets, VirtualTarget)
+            assert isinstance(properties, property_set.PropertySet)
         return [property_set.empty(), source_targets]
 
     def compute_usage_requirements(self, subvariant):
+        if __debug__:
+            from .virtual_target import Subvariant
+            assert isinstance(subvariant, Subvariant)
         base = targets.BasicTarget.compute_usage_requirements(self, subvariant)
         # Add source's usage requirement. If we don't do this, "alias" does not
         # look like 100% alias.
@@ -47,7 +55,11 @@ class AliasTarget(targets.BasicTarget):
 
 @metatarget
 def alias(name, sources=[], requirements=[], default_build=[], usage_requirements=[]):
-
+    assert isinstance(name, basestring)
+    assert is_iterable_typed(sources, basestring)
+    assert is_iterable_typed(requirements, basestring)
+    assert is_iterable_typed(default_build, basestring)
+    assert is_iterable_typed(usage_requirements, basestring)
     project = get_manager().projects().current()
     targets = get_manager().targets()
 

--- a/src/build/build_request.py
+++ b/src/build/build_request.py
@@ -11,12 +11,14 @@ import b2.build.feature
 feature = b2.build.feature
 
 from b2.util.utility import *
+from b2.util import is_iterable_typed
 import b2.build.property_set as property_set
 
 def expand_no_defaults (property_sets):
     """ Expand the given build request by combining all property_sets which don't
         specify conflicting non-free features.
     """
+    assert is_iterable_typed(property_sets, property_set.PropertySet)
     # First make all features and subfeatures explicit
     expanded_property_sets = [ps.expand_subfeatures() for ps in property_sets]
     
@@ -30,6 +32,7 @@ def __x_product (property_sets):
     """ Return the cross-product of all elements of property_sets, less any
         that would contain conflicting values for single-valued features.
     """
+    assert is_iterable_typed(property_sets, property_set.PropertySet)
     x_product_seen = set()
     return __x_product_aux (property_sets, x_product_seen)[0]
 
@@ -44,6 +47,8 @@ def __x_product_aux (property_sets, seen_features):
     have the same feature, and no Property is for feature in seen_features.
     - set of features we saw in property_sets      
     """
+    assert is_iterable_typed(property_sets, property_set.PropertySet)
+    assert isinstance(seen_features, set)
     if not property_sets:
         return ([], set())
 
@@ -90,6 +95,7 @@ def __x_product_aux (property_sets, seen_features):
 def looks_like_implicit_value(v):
     """Returns true if 'v' is either implicit value, or
     the part before the first '-' symbol is implicit value."""
+    assert isinstance(v, basestring)
     if feature.is_implicit_value(v):
         return 1
     else:
@@ -104,7 +110,7 @@ def from_command_line(command_line):
     and constructs build request from it. Returns a list of two
     lists. First is the set of targets specified in the command line,
     and second is the set of requested build properties."""
-
+    assert is_iterable_typed(command_line, basestring)
     targets = []
     properties = []
 
@@ -122,7 +128,7 @@ def from_command_line(command_line):
 # Converts one element of command line build request specification into
 # internal form.
 def convert_command_line_element(e):
-
+    assert isinstance(e, basestring)
     result = None
     parts = e.split("/")
     for p in parts:

--- a/src/build/configure.py
+++ b/src/build/configure.py
@@ -16,11 +16,11 @@
 import b2.build.property as property
 import b2.build.property_set as property_set
 
-import b2.build.targets
+from b2.build import targets as targets_
 
 from b2.manager import get_manager
 from b2.util.sequence import unique
-from b2.util import bjam_signature, value_to_jam
+from b2.util import bjam_signature, value_to_jam, is_iterable
 
 import bjam
 import os
@@ -41,17 +41,22 @@ __log_fd = -1
 
 def register_components(components):
     """Declare that the components specified by the parameter exist."""
+    assert is_iterable(components)
     __components.extend(components)
-    
+
 def components_building(components):
     """Declare that the components specified by the parameters will be build."""
+    assert is_iterable(components)
     __built_components.extend(components)
 
 def log_component_configuration(component, message):
     """Report something about component configuration that the user should better know."""
+    assert isinstance(component, basestring)
+    assert isinstance(message, basestring)
     __component_logs.setdefault(component, []).append(message)
 
 def log_check_result(result):
+    assert isinstance(result, basestring)
     global __announced_checks
     if not __announced_checks:
         print "Performing configuration checks"
@@ -60,7 +65,9 @@ def log_check_result(result):
     print result
 
 def log_library_search_result(library, result):
-    log_check_result(("    - %(library)s : %(result)s" % locals()).rjust(width))
+    assert isinstance(library, basestring)
+    assert isinstance(result, basestring)
+    log_check_result(("    - %(library)s : %(result)s" % locals()).rjust(__width))
 
 
 def print_component_configuration():
@@ -84,6 +91,10 @@ def builds(metatarget_reference, project, ps, what):
     # Attempt to build a metatarget named by 'metatarget-reference'
     # in context of 'project' with properties 'ps'.
     # Returns non-empty value if build is OK.
+    assert isinstance(metatarget_reference, basestring)
+    assert isinstance(project, targets_.ProjectTarget)
+    assert isinstance(ps, property_set.PropertySet)
+    assert isinstance(what, basestring)
 
     result = []
 
@@ -93,7 +104,7 @@ def builds(metatarget_reference, project, ps, what):
         result = False
         __builds_cache[(what, ps)] = False
 
-        targets = b2.build.targets.generate_from_reference(
+        targets = targets_.generate_from_reference(
             metatarget_reference, project, ps).targets()
         jam_targets = []
         for t in targets:
@@ -112,6 +123,7 @@ def builds(metatarget_reference, project, ps, what):
         return existing
 
 def set_log_file(log_file_name):
+    assert isinstance(log_file_name, basestring)
     # Called by Boost.Build startup code to specify name of a file
     # that will receive results of configure checks.  This
     # should never be called by users.
@@ -134,7 +146,7 @@ class CheckTargetBuildsWorker:
         self.false_properties = property.create_from_strings(false_properties, True)
 
     def check(self, ps):
-        
+        assert isinstance(ps, property_set.PropertySet)
         # FIXME: this should not be hardcoded. Other checks might
         # want to consider different set of features as relevant.
         toolset = ps.get('toolset')[0]

--- a/src/build/engine.py
+++ b/src/build/engine.py
@@ -10,46 +10,50 @@ import operator
 import re
 
 import b2.build.property_set as property_set
-import b2.util
 
-class BjamAction:
+from b2.util import set_jam_action, is_iterable
+
+class BjamAction(object):
     """Class representing bjam action defined from Python."""
     
     def __init__(self, action_name, function):
+        assert isinstance(action_name, basestring)
+        assert callable(function) or function is None
         self.action_name = action_name
         self.function = function
-            
-    def __call__(self, targets, sources, property_set):
 
+    def __call__(self, targets, sources, property_set_):
+        assert is_iterable(targets)
+        assert is_iterable(sources)
+        assert isinstance(property_set_, property_set.PropertySet)
         # Bjam actions defined from Python have only the command
         # to execute, and no associated jam procedural code. So
         # passing 'property_set' to it is not necessary.
         bjam_interface.call("set-update-action", self.action_name,
                             targets, sources, [])
         if self.function:
-            self.function(targets, sources, property_set)
+            self.function(targets, sources, property_set_)
 
-class BjamNativeAction:
+class BjamNativeAction(BjamAction):
     """Class representing bjam action defined by Jam code.
 
     We still allow to associate a Python callable that will
     be called when this action is installed on any target.
     """
-    
-    def __init__(self, action_name, function):
-        self.action_name = action_name
-        self.function = function
-        
-    def __call__(self, targets, sources, property_set):
+
+    def __call__(self, targets, sources, property_set_):
+        assert is_iterable(targets)
+        assert is_iterable(sources)
+        assert isinstance(property_set_, property_set.PropertySet)
         if self.function:
-            self.function(targets, sources, property_set)
-        
+            self.function(targets, sources, property_set_)
+
         p = []
         if property_set:
-            p = property_set.raw()
+            p = property_set_.raw()
 
-        b2.util.set_jam_action(self.action_name, targets, sources, p)
-        
+        set_jam_action(self.action_name, targets, sources, p)
+
 action_modifiers = {"updated": 0x01,
                     "together": 0x02,
                     "ignore": 0x04,
@@ -77,6 +81,8 @@ class Engine:
             targets = [targets]
         if isinstance (sources, str):
             sources = [sources]
+        assert is_iterable(targets)
+        assert is_iterable(sources)
 
         for target in targets:
             for source in sources:
@@ -105,6 +111,11 @@ class Engine:
             echo [ on $(targets) return $(MY-VAR) ] ;
             "Hello World"
         """
+        if isinstance(targets, str):
+            targets = [targets]
+        assert is_iterable(targets)
+        assert isinstance(variable, basestring)
+
         return bjam_interface.call('get-target-variable', targets, variable)
 
     def set_target_variable (self, targets, variable, value, append=0):
@@ -114,13 +125,19 @@ class Engine:
         where to generate targets, and will also be available to
         updating rule for that 'taret'.
         """
-        if isinstance (targets, str): 
+        if isinstance (targets, str):
             targets = [targets]
+        if isinstance(value, str):
+            value = [value]
+
+        assert is_iterable(targets)
+        assert isinstance(variable, basestring)
+        assert is_iterable(value)
 
         for target in targets:
             self.do_set_target_variable (target, variable, value, append)
 
-    def set_update_action (self, action_name, targets, sources, properties=property_set.empty()):
+    def set_update_action (self, action_name, targets, sources, properties=None):
         """ Binds a target to the corresponding update action.
             If target needs to be updated, the action registered
             with action_name will be used.
@@ -128,9 +145,17 @@ class Engine:
             either 'register_action' or 'register_bjam_action'
             method.
         """
-        assert(isinstance(properties, property_set.PropertySet))
-        if isinstance (targets, str): 
+        if isinstance(targets, str):
             targets = [targets]
+        if isinstance(sources, str):
+            sources = [sources]
+        if properties is None:
+            properties = property_set.empty()
+        assert isinstance(action_name, basestring)
+        assert is_iterable(targets)
+        assert is_iterable(sources)
+        assert(isinstance(properties, property_set.PropertySet))
+
         self.do_set_update_action (action_name, targets, sources, properties)
 
     def register_action (self, action_name, command, bound_list = [], flags = [],
@@ -149,10 +174,13 @@ class Engine:
         This function will be called by set_update_action, and can
         set additional target variables.
         """
+        assert isinstance(action_name, basestring)
+        assert isinstance(command, basestring)
+        assert is_iterable(bound_list)
+        assert is_iterable(flags)
+        assert function is None or callable(function)
         if self.actions.has_key(action_name):
             raise "Bjam action %s is already defined" % action_name
-
-        assert(isinstance(flags, list))
 
         bjam_flags = reduce(operator.or_,
                             (action_modifiers[flag] for flag in flags), 0)
@@ -178,25 +206,37 @@ class Engine:
         # action name.  This way, jamfile rules that take action names
         # can just register them without specially checking if
         # action is already registered.
+        assert isinstance(action_name, basestring)
+        assert function is None or callable(function)
         if not self.actions.has_key(action_name):
             self.actions[action_name] = BjamNativeAction(action_name, function)
-    
+
     # Overridables
 
 
-    def do_set_update_action (self, action_name, targets, sources, property_set):
+    def do_set_update_action (self, action_name, targets, sources, property_set_):
+        assert isinstance(action_name, basestring)
+        assert is_iterable(targets)
+        assert is_iterable(sources)
+        assert isinstance(property_set_, property_set.PropertySet)
         action = self.actions.get(action_name)
         if not action:
             raise Exception("No action %s was registered" % action_name)
-        action(targets, sources, property_set)
+        action(targets, sources, property_set_)
 
     def do_set_target_variable (self, target, variable, value, append):
+        assert isinstance(target, basestring)
+        assert isinstance(variable, basestring)
+        assert is_iterable(value)
+        assert isinstance(append, int)  # matches bools
         if append:
             bjam_interface.call("set-target-variable", target, variable, value, "true")
         else:
             bjam_interface.call("set-target-variable", target, variable, value)
-        
+
     def do_add_dependency (self, target, source):
+        assert isinstance(target, basestring)
+        assert isinstance(source, basestring)
         bjam_interface.call("DEPENDS", target, source)
-         
-        
+
+

--- a/src/build/property_set.py
+++ b/src/build/property_set.py
@@ -8,6 +8,7 @@
 
 import hashlib
 
+import bjam
 from b2.util.utility import *
 import property, feature
 import b2.build.feature
@@ -15,7 +16,7 @@ from b2.exceptions import *
 from b2.build.property import get_abbreviated_paths
 from b2.util.sequence import unique
 from b2.util.set import difference
-from b2.util import cached, abbreviate_dashed
+from b2.util import cached, abbreviate_dashed, is_iterable_typed
 
 from b2.manager import get_manager
 
@@ -36,6 +37,8 @@ def create (raw_properties = []):
     """ Creates a new 'PropertySet' instance for the given raw properties,
         or returns an already existing one.
     """
+    assert (is_iterable_typed(raw_properties, property.Property)
+            or is_iterable_typed(raw_properties, basestring))
     # FIXME: propagate to callers.
     if len(raw_properties) > 0 and isinstance(raw_properties[0], property.Property):
         x = raw_properties
@@ -58,6 +61,7 @@ def create_with_validation (raw_properties):
         that all properties are valid and converting implicit
         properties into gristed form.
     """
+    assert is_iterable_typed(raw_properties, basestring)
     properties = [property.create_from_string(s) for s in raw_properties]
     property.validate(properties)
 
@@ -71,7 +75,9 @@ def empty ():
 def create_from_user_input(raw_properties, jamfile_module, location):
     """Creates a property-set from the input given by the user, in the
     context of 'jamfile-module' at 'location'"""
-
+    assert is_iterable_typed(raw_properties, basestring)
+    assert isinstance(jamfile_module, basestring)
+    assert isinstance(location, basestring)
     properties = property.create_from_strings(raw_properties, True)
     properties = property.translate_paths(properties, location)
     properties = property.translate_indirect(properties, jamfile_module)
@@ -95,7 +101,10 @@ def refine_from_user_input(parent_requirements, specification, jamfile_module,
      - project-module -- the module to which context indirect features
        will be bound.
      - location -- the path to which path features are relative."""
-
+    assert isinstance(parent_requirements, PropertySet)
+    assert is_iterable_typed(specification, basestring)
+    assert isinstance(jamfile_module, basestring)
+    assert isinstance(location, basestring)
 
     if not specification:
         return parent_requirements
@@ -146,7 +155,7 @@ class PropertySet:
           caching whenever possible.
     """
     def __init__ (self, properties = []):
-
+        assert is_iterable_typed(properties, property.Property)
 
         raw_properties = []
         for p in properties:
@@ -304,6 +313,7 @@ class PropertySet:
         return self.subfeatures_
 
     def evaluate_conditionals(self, context=None):
+        assert isinstance(context, (PropertySet, type(None)))
         if not context:
             context = self
 
@@ -410,6 +420,7 @@ class PropertySet:
         """ Creates a new property set containing the properties in this one,
             plus the ones of the property set passed as argument.
         """
+        assert isinstance(ps, PropertySet)
         if not self.added_.has_key(ps):
             self.added_[ps] = create(self.all_ + ps.all())
         return self.added_[ps]
@@ -428,6 +439,7 @@ class PropertySet:
             feature = feature[0]
         if not isinstance(feature, b2.build.feature.Feature):
             feature = b2.build.feature.get(feature)
+        assert isinstance(feature, b2.build.feature.Feature)
 
         if not self.feature_map_:
             self.feature_map_ = {}
@@ -442,9 +454,9 @@ class PropertySet:
     @cached
     def get_properties(self, feature):
         """Returns all contained properties associated with 'feature'"""
-
         if not isinstance(feature, b2.build.feature.Feature):
             feature = b2.build.feature.get(feature)
+        assert isinstance(feature, b2.build.feature.Feature)
 
         result = []
         for p in self.all_:

--- a/src/build/scanner.py
+++ b/src/build/scanner.py
@@ -34,6 +34,8 @@ import bjam
 import os
 from b2.exceptions import *
 from b2.manager import get_manager
+from b2.util import is_iterable_typed
+
 
 def reset ():
     """ Clear the module state. This is mainly for testing purposes.
@@ -56,6 +58,8 @@ def register(scanner_class, relevant_properties):
         properties relevant to this scanner.  Ctor for that class
         should have one parameter: list of properties.
     """
+    assert issubclass(scanner_class, Scanner)
+    assert isinstance(relevant_properties, basestring)
     __scanners[str(scanner_class)] = relevant_properties
 
 def registered(scanner_class):
@@ -67,6 +71,8 @@ def get(scanner_class, properties):
     """ Returns an instance of previously registered scanner
         with the specified properties.
     """
+    assert issubclass(scanner_class, Scanner)
+    assert is_iterable_typed(properties, basestring)
     scanner_name = str(scanner_class)
     
     if not registered(scanner_name):
@@ -130,6 +136,9 @@ class ScannerRegistry:
         """ Installs the specified scanner on actual target 'target'. 
             vtarget: virtual target from which 'target' was actualized.
         """
+        assert isinstance(scanner, Scanner)
+        assert isinstance(target, basestring)
+        assert isinstance(vtarget, basestring)
         engine = self.manager_.engine()
         engine.set_target_variable(target, "HDRSCAN", scanner.pattern())
         if not self.exported_scanners_.has_key(scanner):
@@ -150,6 +159,8 @@ class ScannerRegistry:
         pass
 
     def propagate(self, scanner, targets):
+        assert isinstance(scanner, Scanner)
+        assert is_iterable_typed(targets, basestring) or isinstance(targets, basestring)
         engine = self.manager_.engine()
         engine.set_target_variable(targets, "HDRSCAN", scanner.pattern())
         engine.set_target_variable(targets, "HDRRULE",

--- a/src/build/type.py
+++ b/src/build/type.py
@@ -14,7 +14,7 @@ import os.path
 from b2.util.utility import replace_grist, os_name
 from b2.exceptions import *
 from b2.build import feature, property, scanner
-from b2.util import bjam_signature
+from b2.util import bjam_signature, is_iterable_typed
 
 
 __re_hyphen = re.compile ('-')
@@ -87,17 +87,17 @@ def register (type, suffixes = [], base_type = None):
         # Generated targets of 'type' will use the first of 'suffixes'
         # (this may be overriden)
         set_generated_target_suffix (type, [], suffixes [0])
-        
+
         # Specify mapping from suffixes to type
         register_suffixes (suffixes, type)
-    
+
     feature.extend('target-type', [type])
     feature.extend('main-target-type', [type])
     feature.extend('base-target-type', [type])
 
     if base_type:
-        feature.compose ('<target-type>' + type, replace_grist (base_type, '<base-target-type>'))
-        feature.compose ('<base-target-type>' + type, '<base-target-type>' + base_type)
+        feature.compose ('<target-type>' + type, [replace_grist (base_type, '<base-target-type>')])
+        feature.compose ('<base-target-type>' + type, ['<base-target-type>' + base_type])
 
     import b2.build.generators as generators
     # Adding a new derived type affects generator selection so we need to
@@ -111,6 +111,7 @@ def register (type, suffixes = [], base_type = None):
 
 # FIXME: quick hack.
 def type_from_rule_name(rule_name):
+    assert isinstance(rule_name, basestring)
     return rule_name.upper().replace("-", "_")
 
 
@@ -118,6 +119,8 @@ def register_suffixes (suffixes, type):
     """ Specifies that targets with suffix from 'suffixes' have the type 'type'. 
         If a different type is already specified for any of syffixes, issues an error.
     """
+    assert is_iterable_typed(suffixes, basestring)
+    assert isinstance(type, basestring)
     for s in suffixes:
         if __suffixes_to_types.has_key (s):
             old_type = __suffixes_to_types [s]
@@ -129,23 +132,33 @@ def register_suffixes (suffixes, type):
 def registered (type):
     """ Returns true iff type has been registered.
     """
+    assert isinstance(type, basestring)
     return __types.has_key (type)
 
 def validate (type):
     """ Issues an error if 'type' is unknown.
     """
+    assert isinstance(type, basestring)
     if not registered (type):
         raise BaseException ("Unknown target type '%s'" % type)
 
 def set_scanner (type, scanner):
     """ Sets a scanner class that will be used for this 'type'.
     """
+    if __debug__:
+        from .scanner import Scanner
+        assert isinstance(type, basestring)
+        assert issubclass(scanner, Scanner)
     validate (type)
     __types [type]['scanner'] = scanner
 
 def get_scanner (type, prop_set):
     """ Returns a scanner instance appropriate to 'type' and 'property_set'.
     """
+    if __debug__:
+        from .property_set import PropertySet
+        assert isinstance(type, basestring)
+        assert isinstance(prop_set, PropertySet)
     if registered (type):
         scanner_type = __types [type]['scanner']
         if scanner_type:
@@ -157,12 +170,13 @@ def get_scanner (type, prop_set):
 def base(type):
     """Returns a base type for the given type or nothing in case the given type is
     not derived."""
-
+    assert isinstance(type, basestring)
     return __types[type]['base']
 
 def all_bases (type):
     """ Returns type and all of its bases, in the order of their distance from type.
     """
+    assert isinstance(type, basestring)
     result = []
     while type:
         result.append (type)
@@ -173,6 +187,7 @@ def all_bases (type):
 def all_derived (type):
     """ Returns type and all classes that derive from it, in the order of their distance from type.
     """
+    assert isinstance(type, basestring)
     result = [type]
     for d in __types [type]['derived']:
         result.extend (all_derived (d))
@@ -182,6 +197,8 @@ def all_derived (type):
 def is_derived (type, base):
     """ Returns true if 'type' is 'base' or has 'base' as its direct or indirect base.
     """
+    assert isinstance(type, basestring)
+    assert isinstance(base, basestring)
     # TODO: this isn't very efficient, especially for bases close to type
     if base in all_bases (type):
         return True
@@ -191,6 +208,8 @@ def is_derived (type, base):
 def is_subtype (type, base):
     """ Same as is_derived. Should be removed.
     """
+    assert isinstance(type, basestring)
+    assert isinstance(base, basestring)
     # TODO: remove this method
     return is_derived (type, base)
 
@@ -208,6 +227,9 @@ def set_generated_target_suffix (type, properties, suffix):
         The 'suffix' parameter can be empty string ("") to indicate that
         no suffix should be used.
     """
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
+    assert isinstance(suffix, basestring)
     set_generated_target_ps(1, type, properties, suffix)
 
 
@@ -216,9 +238,16 @@ def change_generated_target_suffix (type, properties, suffix):
     """ Change the suffix previously registered for this type/properties 
         combination. If suffix is not yet specified, sets it.
     """
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
+    assert isinstance(suffix, basestring)
     change_generated_target_ps(1, type, properties, suffix)
 
 def generated_target_suffix(type, properties):
+    if __debug__:
+        from .property_set import PropertySet
+        assert isinstance(type, basestring)
+        assert isinstance(properties, PropertySet)
     return generated_target_ps(1, type, properties)
 
 # Sets a target prefix that should be used when generating targets of 'type'
@@ -236,16 +265,31 @@ def set_generated_target_prefix(type, properties, prefix):
 # Change the prefix previously registered for this type/properties combination.
 # If prefix is not yet specified, sets it.
 def change_generated_target_prefix(type, properties, prefix):
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
+    assert isinstance(prefix, basestring)
     change_generated_target_ps(0, type, properties, prefix)
 
 def generated_target_prefix(type, properties):
+    if __debug__:
+        from .property_set import PropertySet
+        assert isinstance(type, basestring)
+        assert isinstance(properties, PropertySet)
     return generated_target_ps(0, type, properties)
 
 def set_generated_target_ps(is_suffix, type, properties, val):
+    assert isinstance(is_suffix, (int, bool))
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
+    assert isinstance(val, basestring)
     properties.append ('<target-type>' + type)
     __prefixes_suffixes[is_suffix].insert (properties, val)
 
 def change_generated_target_ps(is_suffix, type, properties, val):
+    assert isinstance(is_suffix, (int, bool))
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
+    assert isinstance(val, basestring)
     properties.append ('<target-type>' + type)
     prev = __prefixes_suffixes[is_suffix].find_replace(properties, val)
     if not prev:
@@ -256,7 +300,9 @@ def change_generated_target_ps(is_suffix, type, properties, val):
 # If no prefix/suffix is specified for 'type', returns prefix/suffix for
 # base type, if any.
 def generated_target_ps_real(is_suffix, type, properties):
-
+    assert isinstance(is_suffix, (int, bool))
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(properties, basestring)
     result = ''
     found = False
     while type and not found:
@@ -278,6 +324,11 @@ def generated_target_ps(is_suffix, type, prop_set):
         with the specified properties. If not suffix were specified for
         'type', returns suffix for base type, if any.
     """
+    if __debug__:
+        from .property_set import PropertySet
+        assert isinstance(is_suffix, (int, bool))
+        assert isinstance(type, basestring)
+        assert isinstance(prop_set, PropertySet)
     key = (is_suffix, type, prop_set)
     v = __target_suffixes_cache.get(key, None)
 
@@ -292,6 +343,7 @@ def type(filename):
         tries each suffix. E.g. for name of "file.so.1.2" suffixes "2", "1", and 
         "so"  will be tried.
     """
+    assert isinstance(filename, basestring)
     while 1:
         filename, suffix = os.path.splitext (filename)
         if not suffix: return None
@@ -306,6 +358,10 @@ def register_type (type, suffixes, base_type = None, os = []):
         if os is not specified.  This rule is injected into each of the type
         modules for the sake of convenience.
     """
+    assert isinstance(type, basestring)
+    assert is_iterable_typed(suffixes, basestring)
+    assert isinstance(base_type, basestring) or base_type is None
+    assert is_iterable_typed(os, basestring)
     if registered (type):
         return
 

--- a/src/tools/cast.py
+++ b/src/tools/cast.py
@@ -25,18 +25,22 @@
 # > cast, as defining a new target type + generator for that type is somewhat
 # > simpler than defining a main target rule.
 
-import b2.build.targets as targets
-import b2.build.virtual_target as virtual_target
+from b2.build import targets, virtual_target, property_set
 
 from b2.manager import get_manager
-from b2.util import bjam_signature
+from b2.util import bjam_signature, is_iterable_typed
+
 
 class CastTargetClass(targets.TypedTarget):
 
-    def construct(name, source_targets, ps):
+    def construct(self, name, source_targets, ps):
+        assert isinstance(name, basestring)
+        assert is_iterable_typed(source_targets, virtual_target.VirtualTarget)
+        assert isinstance(ps, property_set.PropertySet)
+
         result = []
         for s in source_targets:
-            if not isinstance(s, virtual_targets.FileTarget):
+            if not isinstance(s, virtual_target.FileTarget):
                 get_manager().errors()("Source to the 'cast' metatager is not a file")
 
             if s.action():
@@ -46,8 +50,8 @@ class CastTargetClass(targets.TypedTarget):
             r = s.clone_with_different_type(self.type())
             result.append(get_manager().virtual_targets().register(r))
 
-        return result
-    
+        return property_set.empty(), result
+
 
 @bjam_signature((["name", "type"], ["sources", "*"], ["requirements", "*"],
                  ["default_build", "*"], ["usage_requirements", "*"]))

--- a/src/tools/common.py
+++ b/src/tools/common.py
@@ -21,7 +21,7 @@ import sys
 import b2.build.virtual_target
 from b2.build import feature, type
 from b2.util.utility import *
-from b2.util import path
+from b2.util import path, is_iterable_typed
 
 __re__before_first_dash = re.compile ('([^-]*)-')
 
@@ -112,6 +112,7 @@ class Configurations(object):
             Returns True if the configuration has been added and False if
             it already exists. Reports an error if the configuration is 'used'.
         """
+        assert isinstance(id, basestring)
         if id in self.used_:
             #FIXME
             errors.error("common: the configuration '$(id)' is in use")
@@ -132,6 +133,7 @@ class Configurations(object):
             'used' and False if it the state wasn't changed. Reports an error
             if the configuration isn't known.
         """
+        assert isinstance(id, basestring)
         if id not in self.all_:
             #FIXME:
             errors.error("common: the configuration '$(id)' is not known")
@@ -154,10 +156,15 @@ class Configurations(object):
 
     def get(self, id, param):
         """ Returns the value of a configuration parameter. """
+        assert isinstance(id, basestring)
+        assert isinstance(param, basestring)
         return self.params_.get(param, {}).get(id)
 
     def set (self, id, param, value):
         """ Sets the value of a configuration parameter. """
+        assert isinstance(id, basestring)
+        assert isinstance(param, basestring)
+        assert is_iterable_typed(value, basestring)
         self.params_.setdefault(param, {})[id] = value
 
 # Ported from trunk@47174
@@ -174,14 +181,11 @@ def check_init_parameters(toolset, requirement, *args):
 
         The return value from this rule is a condition to be used for flags settings.
     """
+    assert isinstance(toolset, basestring)
+    assert is_iterable_typed(requirement, basestring)
     from b2.build import toolset as b2_toolset
     if requirement is None:
         requirement = []
-    # The type checking here is my best guess about
-    # what the types should be.
-    assert(isinstance(toolset, str))
-    # iterable and not a string, allows for future support of sets
-    assert(not isinstance(requirement, basestring) and hasattr(requirement, '__contains__'))
     sig = toolset
     condition = replace_grist(toolset, '<toolset>')
     subcondition = []
@@ -290,15 +294,12 @@ def get_invocation_command_nodefault(
         find the tool, a warning is issued. If 'path-last' is specified, PATH is
         checked after 'additional-paths' when searching for 'tool'.
     """
-    assert(isinstance(toolset, str))
-    assert(isinstance(tool, str))
-    assert(isinstance(user_provided_command, list))
-    if additional_paths is not None:
-        assert(isinstance(additional_paths, list))
-        assert(all([isinstance(path, str) for path in additional_paths]))
-    assert(all(isinstance(path, str) for path in additional_paths))
-    assert(isinstance(path_last, bool))
-    
+    assert isinstance(toolset, basestring)
+    assert isinstance(tool, basestring)
+    assert is_iterable_typed(user_provided_command, basestring)
+    assert is_iterable_typed(additional_paths, basestring) or additional_paths is None
+    assert isinstance(path_last, (int, bool))
+
     if not user_provided_command:
         command = find_tool(tool, additional_paths, path_last) 
         if not command and __debug_configuration:
@@ -307,13 +308,13 @@ def get_invocation_command_nodefault(
             #print "warning: initialized from" [ errors.nearest-user-location ] ;
     else:
         command = check_tool(user_provided_command)
-        assert(isinstance(command, list))
-        command=' '.join(command)
         if not command and __debug_configuration:
             print "warning: toolset", toolset, "initialization:"
             print "warning: can't find user-provided command", user_provided_command
             #FIXME
             #ECHO "warning: initialized from" [ errors.nearest-user-location ]
+            command = []
+        command = ' '.join(command)
 
     assert(isinstance(command, str))
     
@@ -325,14 +326,11 @@ def get_invocation_command(toolset, tool, user_provided_command = [],
     """ Same as get_invocation_command_nodefault, except that if no tool is found,
         returns either the user-provided-command, if present, or the 'tool' parameter.
     """
-
-    assert(isinstance(toolset, str))
-    assert(isinstance(tool, str))
-    assert(isinstance(user_provided_command, list))
-    if additional_paths is not None:
-        assert(isinstance(additional_paths, list))
-        assert(all([isinstance(path, str) for path in additional_paths]))
-    assert(isinstance(path_last, bool))
+    assert isinstance(toolset, basestring)
+    assert isinstance(tool, basestring)
+    assert is_iterable_typed(user_provided_command, basestring)
+    assert is_iterable_typed(additional_paths, basestring) or additional_paths is None
+    assert isinstance(path_last, (int, bool))
 
     result = get_invocation_command_nodefault(toolset, tool,
                                               user_provided_command,
@@ -356,6 +354,7 @@ def get_absolute_tool_path(command):
         return the absolute path to the command. This works even if commnad
         has not path element and is present in PATH.
     """
+    assert isinstance(command, basestring)
     if os.path.dirname(command):
         return os.path.dirname(command)
     else:
@@ -376,9 +375,9 @@ def find_tool(name, additional_paths = [], path_last = False):
         Otherwise, returns the empty string.  If 'path_last' is specified,
         path is checked after 'additional_paths'.
     """
-    assert(isinstance(name, str))
-    assert(isinstance(additional_paths, list))
-    assert(isinstance(path_last, bool))
+    assert isinstance(name, basestring)
+    assert is_iterable_typed(additional_paths, basestring)
+    assert isinstance(path_last, (int, bool))
 
     programs = path.programs_path()
     match = path.glob(programs, [name, name + '.exe'])
@@ -407,7 +406,7 @@ def check_tool_aux(command):
     """ Checks if 'command' can be found either in path
         or is a full name to an existing file.
     """
-    assert(isinstance(command, str))
+    assert isinstance(command, basestring)
     dirname = os.path.dirname(command)
     if dirname:
         if os.path.exists(command):
@@ -430,8 +429,7 @@ def check_tool(command):
         If comand is absolute path, check that it exists. Returns 'command'
         if ok and empty string otherwise.
     """
-    assert(isinstance(command, list))
-    assert(all(isinstance(c, str) for c in command))
+    assert is_iterable_typed(command, basestring)
     #FIXME: why do we check the first and last elements????
     if check_tool_aux(command[0]) or check_tool_aux(command[-1]):
         return command
@@ -449,11 +447,10 @@ def handle_options(tool, condition, command, options):
     """
     from b2.build import toolset
 
-    assert(isinstance(tool, str))
-    assert(isinstance(condition, list))
-    assert(isinstance(command, str))
-    assert(isinstance(options, list))
-    assert(command)
+    assert isinstance(tool, basestring)
+    assert is_iterable_typed(condition, basestring)
+    assert command and isinstance(command, basestring)
+    assert is_iterable_typed(options, basestring)
     toolset.flags(tool, 'CONFIG_COMMAND', condition, [command])
     toolset.flags(tool + '.compile', 'OPTIONS', condition, feature.get_values('<compileflags>', options))
     toolset.flags(tool + '.compile.c', 'OPTIONS', condition, feature.get_values('<cflags>', options))
@@ -490,8 +487,8 @@ def variable_setting_command(variable, value):
         words, on Unix systems, the variable is exported, which is consistent with the
         only possible behavior on Windows systems.
     """
-    assert(isinstance(variable, str))
-    assert(isinstance(value, str))
+    assert isinstance(variable, basestring)
+    assert isinstance(value, basestring)
 
     if os_name() == 'NT':
         return "set " + variable + "=" + value + os.linesep
@@ -533,8 +530,8 @@ def path_variable_setting_command(variable, paths):
         Returns a command to sets a named shell path variable to the given NATIVE
         paths on the current platform.
     """
-    assert(isinstance(variable, str))
-    assert(isinstance(paths, list))
+    assert isinstance(variable, basestring)
+    assert is_iterable_typed(paths, basestring)
     sep = os.path.pathsep
     return variable_setting_command(variable, sep.join(paths))
 
@@ -542,7 +539,9 @@ def prepend_path_variable_command(variable, paths):
     """
         Returns a command that prepends the given paths to the named path variable on
         the current platform.
-    """    
+    """
+    assert isinstance(variable, basestring)
+    assert is_iterable_typed(paths, basestring)
     return path_variable_setting_command(variable,
         paths + os.environ.get(variable, "").split(os.pathsep))
 
@@ -562,6 +561,7 @@ __mkdir_set = set()
 __re_windows_drive = re.compile(r'^.*:\$')
 
 def mkdir(engine, target):
+    assert isinstance(target, basestring)
     # If dir exists, do not update it. Do this even for $(DOT).
     bjam.call('NOUPDATE', target)
 
@@ -642,9 +642,12 @@ def format_name(format, name, target_type, prop_set):
         The returned name also has the target type specific prefix and suffix which
         puts it in a ready form to use as the value from a custom tag rule.
     """
-    assert(isinstance(format, list))
-    assert(isinstance(name, str))
-    assert(isinstance(target_type, str) or not type)
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert is_iterable_typed(format, basestring)
+        assert isinstance(name, basestring)
+        assert isinstance(target_type, basestring)
+        assert isinstance(prop_set, PropertySet)
     # assert(isinstance(prop_set, property_set.PropertySet))
     if type.is_derived(target_type, 'LIB'):
         result = "" ;
@@ -690,6 +693,8 @@ def format_name(format, name, target_type, prop_set):
         return result
 
 def join_tag(joiner, tag):
+    assert isinstance(joiner, basestring)
+    assert isinstance(tag, basestring)
     if tag:
         if not joiner: joiner = '-'
         return joiner + tag
@@ -698,6 +703,11 @@ def join_tag(joiner, tag):
 __re_toolset_version = re.compile(r"<toolset.*version>(\d+)[.](\d*)")
 
 def toolset_tag(name, target_type, prop_set):
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert isinstance(name, basestring)
+        assert isinstance(target_type, basestring)
+        assert isinstance(prop_set, PropertySet)
     tag = ''
 
     properties = prop_set.raw()
@@ -708,7 +718,7 @@ def toolset_tag(name, target_type, prop_set):
     elif tools.startswith('como'): tag += 'como'
     elif tools.startswith('cw'): tag += 'cw'
     elif tools.startswith('darwin'): tag += 'xgcc'
-    elif tools.startswith('edg'): tag += edg
+    elif tools.startswith('edg'): tag += 'edg'
     elif tools.startswith('gcc'):
         flavor = prop_set.get('<toolset-gcc:flavor>')
         ''.find
@@ -764,6 +774,11 @@ def toolset_tag(name, target_type, prop_set):
 
 
 def threading_tag(name, target_type, prop_set):
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert isinstance(name, basestring)
+        assert isinstance(target_type, basestring)
+        assert isinstance(prop_set, PropertySet)
     tag = ''
     properties = prop_set.raw()
     if '<threading>multi' in properties: tag = 'mt'
@@ -772,6 +787,11 @@ def threading_tag(name, target_type, prop_set):
 
 
 def runtime_tag(name, target_type, prop_set ):
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert isinstance(name, basestring)
+        assert isinstance(target_type, basestring)
+        assert isinstance(prop_set, PropertySet)
     tag = ''
 
     properties = prop_set.raw()

--- a/src/tools/testing.py
+++ b/src/tools/testing.py
@@ -45,7 +45,7 @@ import b2.build_system as build_system
 
 
 from b2.manager import get_manager
-from b2.util import stem, bjam_signature
+from b2.util import stem, bjam_signature, is_iterable_typed
 from b2.util.sequence import unique
 
 import bjam
@@ -88,7 +88,10 @@ __all_tests = []
 # Helper rule. Create a test target, using basename of first source if no target
 # name is explicitly passed. Remembers the created target in a global variable.
 def make_test(target_type, sources, requirements, target_name=None):
-
+    assert isinstance(target_type, basestring)
+    assert is_iterable_typed(sources, basestring)
+    assert is_iterable_typed(requirements, basestring)
+    assert isinstance(target_type, basestring) or target_type is None
     if not target_name:
         target_name = stem(os.path.basename(sources[0]))
 
@@ -189,7 +192,7 @@ __ln1 = re.compile("/(tools|libs)/(.*)/(test|example)")
 __ln2 = re.compile("/(tools|libs)/(.*)$")
 __ln3 = re.compile("(/status$)")
 def get_library_name(path):
-    
+    assert isinstance(path, basestring)
     path = path.replace("\\", "/")
     match1 = __ln1.match(path)
     match2 = __ln2.match(path)
@@ -216,6 +219,7 @@ __out_xml = option.get("out-xml", False, True)
 #   - relative location of all source from the project root.
 #
 def dump_test(target):
+    assert isinstance(target, targets.AbstractTarget)
     type = target.type()
     name = target.name()
     project = target.project()
@@ -298,7 +302,11 @@ generators.register_composing("testing.time", [], ["TIME"])
 # contained in testing-aux.jam, which we load into Jam module named 'testing'
 
 def run_path_setup(target, sources, ps):
-
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert is_iterable_typed(target, basestring) or isinstance(target, basestring)
+        assert is_iterable_typed(sources, basestring)
+        assert isinstance(ps, PropertySet)
     # For testing, we need to make sure that all dynamic libraries needed by the
     # test are found. So, we collect all paths from dependency libraries (via
     # xdll-path property) and add whatever explicit dll-path user has specified.
@@ -313,7 +321,12 @@ def run_path_setup(target, sources, ps):
                      common.shared_library_path_variable(), dll_paths))
 
 def capture_output_setup(target, sources, ps):
-    run_path_setup(target, sources, ps)
+    if __debug__:
+        from ..build.property_set import PropertySet
+        assert is_iterable_typed(target, basestring)
+        assert is_iterable_typed(sources, basestring)
+        assert isinstance(ps, PropertySet)
+    run_path_setup(target[0], sources, ps)
 
     if ps.get('preserve-test-targets') == ['off']:
         bjam.call("set-target-variable", target, "REMOVE_TEST_TARGETS", "1")

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -6,14 +6,153 @@ import types
 from itertools import groupby
 
 
+def safe_isinstance(value, types=None, class_names=None):
+    """To prevent circular imports, this extends isinstance()
+    by checking also if `value` has a particular class name (or inherits from a
+    particular class name). This check is safe in that an AttributeError is not
+    raised in case `value` doesn't have a __class__ attribute.
+    """
+    # inspect is being imported here because I seriously doubt
+    # that this function will be used outside of the type
+    # checking below.
+    import inspect
+    result = False
+    if types is not None:
+        result = result or isinstance(value, types)
+    if class_names is not None and not result:
+        # this doesn't work with inheritance, but normally
+        # either the class will already be imported within the module,
+        # or the class doesn't have any subclasses. For example: PropertySet
+        if isinstance(class_names, basestring):
+            class_names = [class_names]
+        # this is the part that makes it "safe".
+        try:
+            base_names = [class_.__name__ for class_ in inspect.getmro(value.__class__)]
+            for name in class_names:
+                if name in base_names:
+                    return True
+        except AttributeError:
+            pass
+    return result
+
+
+def is_iterable_typed(values, type_):
+    return is_iterable(values) and all(isinstance(v, type_) for v in values)
+
+
+def is_iterable(value):
+    """Returns whether value is iterable and not a string."""
+    return not isinstance(value, basestring) and hasattr(value, '__iter__')
+
+
+def is_iterable_or_none(value):
+    return is_iterable(value) or value is None
+
+
+def is_single_value(value):
+    # some functions may specify a bjam signature
+    # that is a string type, but still allow a
+    # PropertySet to be passed in
+    return safe_isinstance(value, (basestring, type(None)), 'PropertySet')
+
+
+if __debug__:
+
+    from textwrap import dedent
+    message = dedent(
+        """The parameter "{}" was passed in a wrong type for the "{}()" function.
+        Actual:
+        \ttype: {}
+        \tvalue: {}
+        Expected:
+        \t{}
+        """
+    )
+
+    bjam_types = {
+        '*': is_iterable_or_none,
+        '+': is_iterable_or_none,
+        '?': is_single_value,
+        '': is_single_value,
+    }
+
+    bjam_to_python = {
+        '*': 'iterable',
+        '+': 'iterable',
+        '?': 'single value',
+        '': 'single value',
+    }
+
+
+    def get_next_var(field):
+        it = iter(field)
+        var = it.next()
+        type_ = None
+        yield_var = False
+        while type_ not in bjam_types:
+            try:
+                # the first value has already
+                # been consumed outside of the loop
+                type_ = it.next()
+            except StopIteration:
+                # if there are no more values, then
+                # var still needs to be returned
+                yield_var = True
+                break
+            if type_ not in bjam_types:
+                # type_ is not a type and is
+                # another variable in the same field.
+                yield var, ''
+                # type_ is the next var
+                var = type_
+            else:
+                # otherwise, type_ is a type for var
+                yield var, type_
+                try:
+                    # the next value should be a var
+                    var = it.next()
+                except StopIteration:
+                    # if not, then we're done with
+                    # this field
+                    break
+        if yield_var:
+            yield var, ''
+
+
 # Decorator the specifies bjam-side prototype for a Python function
 def bjam_signature(s):
+    if __debug__:
+        from inspect import getcallargs
+        def decorator(fn):
+            function_name = fn.__module__ + '.' + fn.__name__
+            def wrapper(*args, **kwargs):
+                callargs = getcallargs(fn, *args, **kwargs)
+                for field in s:
+                    for var, type_ in get_next_var(field):
+                        try:
+                            value = callargs[var]
+                        except KeyError:
+                            raise Exception(
+                                'Bjam Signature specifies a variable named "{}"\n'
+                                'but is not found within the python function signature\n'
+                                'for function {}()'.format(var, function_name)
+                            )
+                        if not bjam_types[type_](value):
+                            raise TypeError(
+                                message.format(var, function_name, type(type_), repr(value),
+                                               bjam_to_python[type_])
+                            )
+                return fn(*args, **kwargs)
+            wrapper.__name__ = fn.__name__
+            wrapper.bjam_signature = s
+            return wrapper
+        return decorator
+    else:
+        def decorator(f):
+            f.bjam_signature = s
+            return f
 
-    def wrap(f):       
-        f.bjam_signature = s
-        return f
-
-    return wrap
+    return decorator
 
 def metatarget(f):
 

--- a/src/util/path.py
+++ b/src/util/path.py
@@ -40,6 +40,7 @@ def make (native):
     # TODO: make os selection here.
     return make_UNIX (native)
 
+@bjam_signature([['native']])
 def make_UNIX (native):
 
     # VP: I have no idea now 'native' can be empty here! But it can!

--- a/src/util/sequence.py
+++ b/src/util/sequence.py
@@ -5,7 +5,11 @@
 
 import operator
 
+from b2.util import is_iterable
+
+
 def unique (values, stable=False):
+    assert is_iterable(values)
     if stable:
         s = set()
         r = []
@@ -21,6 +25,8 @@ def max_element (elements, ordered = None):
     """ Returns the maximum number in 'elements'. Uses 'ordered' for comparisons,
         or '<' is none is provided.
     """
+    assert is_iterable(elements)
+    assert callable(ordered) or ordered is None
     if not ordered: ordered = operator.lt
 
     max = elements [0]
@@ -34,6 +40,8 @@ def select_highest_ranked (elements, ranks):
     """ Returns all of 'elements' for which corresponding element in parallel
         list 'rank' is equal to the maximum value in 'rank'.
     """
+    assert is_iterable(elements)
+    assert is_iterable(ranks)
     if not elements:
         return []
 

--- a/src/util/set.py
+++ b/src/util/set.py
@@ -3,11 +3,15 @@
 #  all copies. This software is provided "as is" without express or implied
 #  warranty, and with no claim as to its suitability for any purpose.
 
-from utility import to_seq
+from b2.util import is_iterable
+from .utility import to_seq
+
 
 def difference (b, a):
     """ Returns the elements of B that are not in A.
     """
+    assert is_iterable(b)
+    assert is_iterable(a)
     result = []
     for element in b:
         if not element in a:
@@ -18,6 +22,8 @@ def difference (b, a):
 def intersection (set1, set2):
     """ Removes from set1 any items which don't appear in set2 and returns the result.
     """
+    assert is_iterable(set1)
+    assert is_iterable(set2)
     result = []
     for v in set1:
         if v in set2:
@@ -39,4 +45,6 @@ def equal (a, b):
     """ Returns True iff 'a' contains the same elements as 'b', irrespective of their order.
         # TODO: Python 2.4 has a proper set class.
     """
+    assert is_iterable(a)
+    assert is_iterable(b)
     return contains (a, b) and contains (b, a)

--- a/src/util/utility.py
+++ b/src/util/utility.py
@@ -11,6 +11,7 @@ import re
 import os
 import bjam
 from b2.exceptions import *
+from b2.util import is_iterable_typed
 
 __re_grist_and_value = re.compile (r'(<[^>]*>)(.*)')
 __re_grist_content = re.compile ('^<(.*)>$')
@@ -40,13 +41,13 @@ def add_grist (features):
         features: one string or a sequence of strings
         return: the gristed string, if features is a string, or a sequence of gristed strings, if features is a sequence
     """
-
+    assert is_iterable_typed(features, basestring) or isinstance(features, basestring)
     def grist_one (feature):
         if feature [0] != '<' and feature [len (feature) - 1] != '>':
             return '<' + feature + '>'
         else:
             return feature
-    
+
     if isinstance (features, str):
         return grist_one (features)
     else:
@@ -56,6 +57,8 @@ def replace_grist (features, new_grist):
     """ Replaces the grist of a string by a new one.
         Returns the string with the new grist.
     """
+    assert is_iterable_typed(features, basestring) or isinstance(features, basestring)
+    assert isinstance(new_grist, basestring)
     def replace_grist_one (name, new_grist):
         split = __re_grist_and_value.match (name)
         if not split:
@@ -71,12 +74,14 @@ def replace_grist (features, new_grist):
 def get_value (property):
     """ Gets the value of a property, that is, the part following the grist, if any.
     """
+    assert is_iterable_typed(property, basestring) or isinstance(property, basestring)
     return replace_grist (property, '')
-    
+
 def get_grist (value):
     """ Returns the grist of a string.
         If value is a sequence, does it for every value and returns the result as a sequence.
     """
+    assert is_iterable_typed(value, basestring) or isinstance(value, basestring)
     def get_grist_one (name):
         split = __re_grist_and_value.match (name)
         if not split:
@@ -93,6 +98,7 @@ def ungrist (value):
     """ Returns the value without grist. 
         If value is a sequence, does it for every value and returns the result as a sequence.
     """
+    assert is_iterable_typed(value, basestring) or isinstance(value, basestring)
     def ungrist_one (value):
         stripped = __re_grist_content.match (value)
         if not stripped:
@@ -109,12 +115,15 @@ def replace_suffix (name, new_suffix):
     """ Replaces the suffix of name by new_suffix.
         If no suffix exists, the new one is added.
     """
+    assert isinstance(name, basestring)
+    assert isinstance(new_suffix, basestring)
     split = os.path.splitext (name)
     return split [0] + new_suffix
 
 def forward_slashes (s):
     """ Converts all backslashes to forward slashes.
     """
+    assert isinstance(s, basestring)
     return __re_backslash.sub ('/', s)
 
 
@@ -122,6 +131,7 @@ def split_action_id (id):
     """ Splits an id in the toolset and specific rule parts. E.g.
         'gcc.compile.c++' returns ('gcc', 'compile.c++')
     """
+    assert isinstance(id, basestring)
     split = id.split ('.', 1)
     toolset = split [0]
     name = ''


### PR DESCRIPTION
These changes change the core engine by loading the python modules in optimization mode by default and allow specifying a flag to disable optimized mode. When optimized mode is on, all `assert` statements as well as `if __debug__` statements are completely removed from the AST before being compiled to bytecode. Both are being used within the `bjam_signature` decorator and a majority of the code within the `build` package.

I am still in the process of porting our large library written in Jam over to Python. I do my best to try and determine the signature of a function/rule based on the usage of a parameter on the Jam side, however, I've been bitten by the same  bug where I've passed in a string when it has expected a list.

After completing the type checking, I've found several other type-bugs which has helped me solve a lot of problems I've been having.

This addresses #54.