### PR TITLE
Update python to match jam. Various other fixes.

### DIFF
--- a/src/build/feature.py
+++ b/src/build/feature.py
@@ -74,6 +74,9 @@ class Feature(object):
     def set_parent(self, feature, value):
         self._parent = (feature, value)
 
+    def __hash__(self):
+        return hash(self._name)
+
     def __str__(self):
         return self._name
 
@@ -706,27 +709,23 @@ def add_defaults (properties):
          
           and that's kind of strange.        
     """
-    result = [x for x in properties]
-    
-    handled_features = set()
-    for p in properties:
-        # We don't add default for conditional properties.  We don't want
-        # <variant>debug:<define>DEBUG to be takes as specified value for <variant>
-        if not p.condition():
-            handled_features.add(p.feature())
-        
+    # create a copy since properties will be modified
+    result = list(properties)
+
+    # We don't add default for conditional properties.  We don't want
+    # <variant>debug:<define>DEBUG to be takes as specified value for <variant>
+    handled_features = set(p.feature() for p in properties if not p.condition())
+
     missing_top = [f for f in __all_top_features if not f in handled_features]
     more = defaults(missing_top)
     result.extend(more)
-    for p in more:
-        handled_features.add(p.feature())
-       
+    handled_features.update(p.feature() for p in more)
+
     # Add defaults for subfeatures of features which are present
     for p in result[:]:
-        s = p.feature().subfeatures()
-        more = defaults([s for s in p.feature().subfeatures() if not s in handled_features])
-        for p in more:
-            handled_features.add(p.feature())
+        subfeatures = [s for s in p.feature().subfeatures() if not s in handled_features]
+        more = defaults(__select_subfeatures(p, subfeatures))
+        handled_features.update(p.feature() for p in more)
         result.extend(more)
     
     return result

--- a/src/build/generators.py
+++ b/src/build/generators.py
@@ -350,21 +350,20 @@ class Generator:
         # bypassed: Targets that can't be consumed and will be returned as-is.
         
         if self.composing_:
-            (consumed, bypassed) = self.convert_multiple_sources_to_consumable_types (project, prop_set, sources)
+            consumed = self.convert_multiple_sources_to_consumable_types (project, prop_set, sources)
         else:
-            (consumed, bypassed) = self.convert_to_consumable_types (project, name, prop_set, sources)
-                
+            consumed = self.convert_to_consumable_types (project, name, prop_set, sources)
+
         result = []
         if consumed:
             result = self.construct_result (consumed, project, name, prop_set)
-            result.extend (bypassed)
 
         if result:
             if project.manager ().logger ().on ():
                 project.manager ().logger ().log (__name__, "  SUCCESS: ", result)
 
         else:
-                project.manager ().logger ().log (__name__, "  FAILURE")
+            project.manager ().logger ().log (__name__, "  FAILURE")
 
         return result
 
@@ -385,12 +384,9 @@ class Generator:
         if len (self.source_types_) < 2 and not self.composing_:
 
             for r in consumed:
-                result.extend (self.generated_targets ([r], prop_set, project, name))
-
-        else:
-
-            if consumed:
-                result.extend (self.generated_targets (consumed, prop_set, project, name))
+                result.extend(self.generated_targets([r], prop_set, project, name))
+        elif consumed:
+            result.extend(self.generated_targets(consumed, prop_set, project, name))
 
         return result
 
@@ -491,12 +487,10 @@ class Generator:
                         error.
                         
             Returns a pair:
-                consumed: all targets that can be consumed. 
-                bypassed: all targets that cannot be consumed.
+                consumed: all targets that can be consumed.
         """
         consumed = []
-        bypassed = []
-        missing_types = [] 
+        missing_types = []
 
         if len (sources) > 1:
             # Don't know how to handle several sources yet. Just try 
@@ -532,50 +526,39 @@ class Generator:
                 if t.type() in missing_types:
                     consumed.append(t)
 
-                else:
-                    bypassed.append(t)
-        
         consumed = unique(consumed)
-        bypassed = unique(bypassed)
-        
-        # remove elements of 'bypassed' that are in 'consumed'
-        
-        # Suppose the target type of current generator, X is produced from 
-        # X_1 and X_2, which are produced from Y by one generator.
-        # When creating X_1 from Y, X_2 will be added to 'bypassed'
-        # Likewise, when creating X_2 from Y, X_1 will be added to 'bypassed'
-        # But they are also in 'consumed'. We have to remove them from
-        # bypassed, so that generators up the call stack don't try to convert
-        # them. 
 
-        # In this particular case, X_1 instance in 'consumed' and X_1 instance
-        # in 'bypassed' will be the same: because they have the same source and
-        # action name, and 'virtual-target.register' won't allow two different
-        # instances. Therefore, it's OK to use 'set.difference'.
-        
-        bypassed = set.difference(bypassed, consumed)
+        return consumed
 
-        return (consumed, bypassed)
-    
 
     def convert_multiple_sources_to_consumable_types (self, project, prop_set, sources):
         """ Converts several files to consumable types.
-        """        
-        consumed = []
-        bypassed = []
+        """
+        if not self.source_types_:
+            return sources
 
-        # We process each source one-by-one, trying to convert it to
-        # a usable type.
-        for s in sources:
-            # TODO: need to check for failure on each source.
-            (c, b) = self.convert_to_consumable_types (project, None, prop_set, [s], True)
-            if not c:
-                project.manager ().logger ().log (__name__, " failed to convert ", s)
+        acceptable_types = set()
+        for t in self.source_types_:
+            acceptable_types.update(type.all_derived(t))
 
-            consumed.extend (c)
-            bypassed.extend (b)
+        result = []
+        for source in sources:
+            if source.type() not in acceptable_types:
+                transformed = construct_types(
+                    project, None,self.source_types_, prop_set, [source])
+                # construct_types returns [prop_set, [targets]]
+                for t in transformed[1]:
+                    if t.type() in self.source_types_:
+                        result.append(t)
+                if not transformed:
+                    project.manager().logger().log(__name__, "  failed to convert ", source)
+            else:
+                result.append(source)
 
-        return (consumed, bypassed)
+        result = sequence.unique(result, stable=True)
+        return result
+
+
 
     def consume_directly (self, source):
         real_source_type = source.type ()
@@ -590,7 +573,7 @@ class Generator:
         for st in source_types:
             # The 'source' if of right type already)
             if real_source_type == st or type.is_derived (real_source_type, st):
-                consumed.append (source)
+                consumed = [source]
 
             else:
                missing_types.append (st)

--- a/src/build/toolset.py
+++ b/src/build/toolset.py
@@ -345,7 +345,7 @@ def __handle_flag_value (manager, value, ps):
                 else:
                     result.extend(value.split ('&&'))
             else:
-                result.append (ungristed)
+                result.append (value)
     else:
         result.append (value)
 

--- a/src/build/type.py
+++ b/src/build/type.py
@@ -70,8 +70,14 @@ def register (type, suffixes = [], base_type = None):
     # which need to be decomposed.
     if __re_hyphen.search (type):
         raise BaseException ('type name "%s" contains a hyphen' % type)
-    
-    if __types.has_key (type):
+
+    # it's possible for a type to be registered with a
+    # base type that hasn't been registered yet. in the
+    # check for base_type below and the following calls to setdefault()
+    # the key `type` will be added to __types. When the base type
+    # actually gets registered, it would fail after the simple check
+    # of "type in __types"; thus the check for "'base' in __types[type]"
+    if type in __types and 'base' in __types[type]:
         raise BaseException ('Type "%s" is already registered.' % type)
 
     entry = {}
@@ -221,17 +227,22 @@ def change_generated_target_suffix (type, properties, suffix):
 def generated_target_suffix(type, properties):
     return generated_target_ps(1, type, properties)
 
-# Sets a target prefix that should be used when generating targets of 'type'
-# with the specified properties. Can be called with empty properties if no
-# prefix for 'type' has been specified yet.
+
+# Sets a file suffix to be used when generating a target of 'type' with the
+# specified properties. Can be called with no properties if no suffix has
+# already been specified for the 'type'. The 'suffix' parameter can be an empty
+# string ("") to indicate that no suffix should be used.
 #
-# The 'prefix' parameter can be empty string ("") to indicate that no prefix
-# should be used.
+# Note that this does not cause files with 'suffix' to be automatically
+# recognized as being of 'type'. Two different types can use the same suffix for
+# their generated files but only one type can be auto-detected for a file with
+# that suffix. User should explicitly specify which one using the
+# register-suffixes rule.
 #
 # Usage example: library names use the "lib" prefix on unix.
 @bjam_signature((["type"], ["properties", "*"], ["suffix"]))
-def set_generated_target_prefix(type, properties, prefix):
-    set_generated_target_ps(0, type, properties, prefix)
+def set_generated_target_prefix(type, properties, suffix):
+    set_generated_target_ps(0, type, properties, suffix)
 
 # Change the prefix previously registered for this type/properties combination.
 # If prefix is not yet specified, sets it.

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -403,6 +403,8 @@ class CScanner (scanner.Scanner):
 scanner.register (CScanner, 'include')
 type.set_scanner ('CPP', CScanner)
 type.set_scanner ('C', CScanner)
+type.set_scanner('H', CScanner)
+type.set_scanner('HPP', CScanner)
 
 # Ported to trunk@47077
 class LibGenerator (generators.Generator):
@@ -706,8 +708,17 @@ class ArchiveGenerator (generators.Generator):
         sources += prop_set.get ('<library>')
         
         result = generators.Generator.run (self, project, name, prop_set, sources)
-             
-        return result
+
+        usage_requirements = []
+        link = prop_set.get('<link>')
+        if 'static' in link:
+            for t in sources:
+                if type.is_derived(t.type(), 'LIB'):
+                    usage_requirements.append(property.Property('<library>', t))
+
+        usage_requirements = property_set.create(usage_requirements)
+
+        return usage_requirements, result
 
 
 def register_archiver(id, source_types, target_types, requirements):

--- a/src/tools/msvc.py
+++ b/src/tools/msvc.py
@@ -380,12 +380,12 @@ def setup_preprocess_c_cpp_action(targets, sources, properties):
     return 'preprocess-c-c++'
     
 register_setup_action(
-    'msvc.preprocess.c',
+    'msvc.compile.c.preprocess',
     setup_preprocess_c_cpp_action,
     function=compile_c_preprocess)
 
 register_setup_action(
-    'msvc.preprocess.c++',
+    'msvc.compile.c++.preprocess',
     setup_preprocess_c_cpp_action,
     function=compile_cpp_preprocess)
 
@@ -816,8 +816,7 @@ def configure_really(version=None, options=[]):
 
         # Get tool names (if any) and finish setup.
         compiler = feature.get_values("<compiler>", options)
-        if not compiler:
-            compiler = "cl"
+        compiler = compiler[0] if compiler else 'cl'
 
         linker = feature.get_values("<linker>", options)
         if not linker:
@@ -965,7 +964,7 @@ def register_toolset_really():
     feature.extend('toolset', ['msvc'])
 
     # Intel and msvc supposedly have link-compatible objects.
-    feature.subfeature( 'toolset', 'msvc', 'vendor', 'intel', ['propagated', 'optional'])
+    feature.subfeature( 'toolset', 'msvc', 'vendor', ['intel'], ['propagated', 'optional'])
 
     # Inherit MIDL flags.
     toolset.inherit_flags('msvc', 'midl')

--- a/src/tools/types/cpp.py
+++ b/src/tools/types/cpp.py
@@ -1,84 +1,10 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-import os
-import re
+from b2.build import type as type_
 
-import bjam
-
-from b2.build import type as type_, scanner
-from b2.manager import get_manager
-from b2.util.utility import replace_grist
-
-
-MANAGER = get_manager()
-ENGINE = MANAGER.engine()
-SCANNERS = MANAGER.scanners()
-
-
-class CScanner(scanner.Scanner):
-    def __init__(self, includes):
-        scanner.Scanner.__init__(self)
-        self.includes = []
-        for include in includes:
-            self.includes.extend(replace_grist(include, '').split('&&'))
-
-    def pattern(self):
-        return '#\s*include\s*(<(.*)>|"(.*)")'
-
-    def process(self, target, matches, binding):
-        # create a single string so that findall
-        # can be used since it returns a list of
-        # all grouped matches
-        match_str = ' '.join(matches)
-        # the question mark makes the regexes non-greedy
-        angles = re.findall(r'<(.*?)>', match_str)
-        quoted = re.findall(r'"(.*?)"', match_str)
-
-        # CONSIDER: the new scoping rules seem to defeat "on target" variables.
-        g = ENGINE.get_target_variable(target, 'HDRGRIST')
-        b = os.path.normpath(os.path.dirname(binding))
-
-        # Attach binding of including file to included targets. When a target is
-        # directly created from a virtual target this extra information is
-        # unnecessary. But in other cases, it allows us to distinguish between
-        # two headers of the same name included from different places. We do not
-        # need this extra information for angle includes, since they should not
-        # depend on the including file (we can not get literal "." in the
-        # include path).
-        # local g2 = $(g)"#"$(b) ;
-        g2 = g + '#' + b
-
-        angles = [replace_grist(angle, g) for angle in angles]
-        quoted = [replace_grist(quote, g2) for quote in quoted]
-
-        includes = angles + quoted
-
-        bjam.call('INCLUDES', target, includes)
-        bjam.call('NOCARE', includes)
-        ENGINE.set_target_variable(angles, 'SEARCH', self.includes)
-        ENGINE.set_target_variable(quoted, 'SEARCH', [b] + self.includes)
-
-        # Just propagate the current scanner to includes, in hope that includes
-        # do not change scanners.
-        SCANNERS.propagate(self, includes)
-
-        bjam.call('ISFILE', includes)
-
-
-scanner.register(CScanner, 'include')
 
 type_.register_type('CPP', ['cpp', 'cxx', 'cc'])
 type_.register_type('H', ['h'])
 type_.register_type('HPP', ['hpp'], 'H')
 type_.register_type('C', ['c'])
-# It most cases where a CPP file or a H file is a source of some action, we
-# should rebuild the result if any of files included by CPP/H are changed. One
-# case when this is not needed is installation, which is handled specifically.
-type_.set_scanner('CPP', CScanner)
-type_.set_scanner('C', CScanner)
-# One case where scanning of H/HPP files is necessary is PCH generation -- if
-# any header included by HPP being precompiled changes, we need to recompile the
-# header.
-type_.set_scanner('H', CScanner)
-type_.set_scanner('HPP', CScanner)


### PR DESCRIPTION
The majority of the changes in this PR are to bring the Python port up to date with the Jam counterparts. Other various bug fixes are included.

### feature.py
- Added `__hash__` to the `Feature` class. `Feature` instances were being used in sets/dicts. When testing if a set/dict contained a specific feature, it would always return `False` since by default an object's hash is its `id`.
- the call to `__select_subfeatures` was missing
- the rest of the changes are just various Pythonic changes and aren't really necessary

### generators.py
- at some point the variable and return value `bypassed` was removed from the Jam code and was not updated in the Python port.
- `convert_multiple_sources_to_consumable_types` was completely different on the Jam side. The Python port has just been updated to reflect the changes.
- There was a slight error in translation from Jam to Python in `consume_directly`

### project.py
- unless I've done something wrong, I wasn't able to call `project.initialize` in the same way that I could in Jam code. I've added the `standalone_path` parameter so that the `source-location` parameter could be properly set.
- with the above change required another change in `load_module`. The `loaded_tool_module_path_[mname]` needed to be set *before* the module was imported.

### property.py
- allow `set_abbreviated_paths` to be called from Jam. Since the default value enables abbreviated paths and it's impossible for Jam to pass in a falsy value, the function now checks to see if the string `off` has been passed and disables appropriately.
- The rest of the changes in `refine` have been added due to a bug that I noticed. I'm not sure if this is the correct place to add it or not. There were certain instances where a property set would have the properties `<toolset>arm` and `<toolset-arm:version>5.4`. Later on, in a call to `refine` when the `requirements` parameter would contain `<toolset>msvc`, the property `<toolset>arm` was being replaced, however, `<toolset-arm:version>5.4` was not. This cause problems later on in a call to `__select_alternatives` in `targets.py` when the best alternative was not being correctly picked due to that incorrect property.

### targets.py
- according to the comments and the code in the corresponding Jam file, a property is free and unconditional if it is also not incidental.
- the rest of the changes are made to bring the port up to date with the Jam

### toolset.py
- `ungristed` is undefined; using the correct variable `value` instead

### type.py
- allow `register` to register an inherited type before the base type is registered
- correct a parameter name in `set_generated_target_suffix`. This was found after implementing the `bjam_signature` type checking in #55.

### builtin.py
- In a previous pull request, I had ported the `CScanner` in the `types/cpp.py` module. I realized later that the `CScanner` had already been ported in the `builtin` module.
- Updated the `LibGenerator` to match the Jam counterpart.

### msvc.py
- fixed an action naming error
- `feature.get_values` returns a list and `compiler` is expected to be a string in the calls to `toolset.flags` later on.
- `feature.subfeature` expects the subfeature value to be a list not a string. This was also found after the type checking from #55.

### cpp.py
- remove the `CScanner` since it has already been ported in the `builtin` module.