### PR TITLE
Add support for more standard library options within sun.jam

### DIFF
--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -22,6 +22,14 @@ feature.extend stdlib : sun-stlport ;
 feature.compose <stdlib>sun-stlport
     : <cxxflags>-library=stlport4 <linkflags>-library=stlport4
     ;
+feature.extend stdlib : apache ;
+feature.compose <stdlib>apache
+    : <cxxflags>-library=stdcxx4 <linkflags>-library=stdcxx4
+    ;
+feature.extend stdlib : cxx11 ;
+feature.compose <stdlib>cxx11
+    : <cxxflags>-std=c++11 <linkflags>-std=c++11
+    ;
 
 rule init ( version ? : command * : options * ) 
 {

--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -23,8 +23,7 @@ generators.override sun.searched-lib-generator : searched-lib-generator ;
 #    also available via -std=sun03.
 # 2) C++03 mode + STLport, selected via the -library option.
 # 3) C++03 mode plus the Apache std lib, selected via the -library option.
-# 4) C++03 mode in g++ compatibility mode, and GNU libstdc++3, selected via -std=c++03.
-# 5) C++11 mode in g++ compatibility mode, and GNU libstdc++3, selected via -std=c++11.
+# 4) C++03 or c++11 in g++ compatibility mode, and GNU libstdc++3, selected via -std=c++03.
 #
 # Note that the -std, -library and -compat compiler switches appear to be largely mutually
 # incompatible, and that going forward the -std switch seems to be the prefered one.
@@ -39,13 +38,9 @@ feature.extend stdlib : apache ;
 feature.compose <stdlib>apache
     : <cxxflags>-library=stdcxx4 <linkflags>-library=stdcxx4
     ;
-feature.extend stdlib : cxx03 ;
-feature.compose <stdlib>cxx03
+feature.extend stdlib : gnu ;
+feature.compose <stdlib>gnu
     : <cxxflags>-std=c++03 <linkflags>-std=c++03
-    ;
-feature.extend stdlib : cxx11 ;
-feature.compose <stdlib>cxx11
-    : <cxxflags>-std=c++11 <linkflags>-std=c++11
     ;
 
 rule init ( version ? : command * : options * ) 

--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -17,7 +17,20 @@ toolset.inherit  sun : unix ;
 generators.override sun.prebuilt : builtin.lib-generator ;
 generators.override sun.prebuilt : builtin.prebuilt ;
 generators.override sun.searched-lib-generator : searched-lib-generator ;
-
+#
+# There are no less than 5 standard library options:
+# 1) The default, which uses an old version of the Rogue Wave std lib,
+#    also available via -std=sun03.
+# 2) C++03 mode + STLport, selected via the -library option.
+# 3) C++03 mode plus the Apache std lib, selected via the -library option.
+# 4) C++03 mode in g++ compatibility mode, and GNU libstdc++3, selected via -std=c++03.
+# 5) C++11 mode in g++ compatibility mode, and GNU libstdc++3, selected via -std=c++11.
+#
+# Note that the -std, -library and -compat compiler switches appear to be largely mutually
+# incompatible, and that going forward the -std switch seems to be the prefered one.
+#
+# See http://docs.oracle.com/cd/E37069_01/html/E37075/bkamw.html#OSSCPgnaof
+#
 feature.extend stdlib : sun-stlport ;
 feature.compose <stdlib>sun-stlport
     : <cxxflags>-library=stlport4 <linkflags>-library=stlport4
@@ -25,6 +38,10 @@ feature.compose <stdlib>sun-stlport
 feature.extend stdlib : apache ;
 feature.compose <stdlib>apache
     : <cxxflags>-library=stdcxx4 <linkflags>-library=stdcxx4
+    ;
+feature.extend stdlib : cxx03 ;
+feature.compose <stdlib>cxx03
+    : <cxxflags>-std=c++03 <linkflags>-std=c++03
     ;
 feature.extend stdlib : cxx11 ;
 feature.compose <stdlib>cxx11


### PR DESCRIPTION
The latest Oracle compiler has several std lib options, all of which work with Boost to some degree or another:

* default C++03 - Rogue Wave
* stlport C++ 03
* Apache C++03
* C++11 - a version of GNU Libstdc++

This patch provides a means to switch between them.