### PR TITLE
WinRT require /ZW

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1164,7 +1164,14 @@ local rule configure-really ( version ? : options * )
                 {
                     setup-script = $(setup-phone-$(c)) ;
                 }
-                toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(compiler) /Zm800 -nologo ;
+                if $(api) = desktop
+                {
+                    toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(compiler) /Zm800 -nologo ;
+                }
+                else
+                {
+                    toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(compiler) /Zm800 /ZW -nologo ;
+                }
                 toolset.flags msvc.compile .ASM <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(cpu-assembler) -nologo ;
                 toolset.flags msvc.link    .LD  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(linker) /NOLOGO /INCREMENTAL:NO ;
                 toolset.flags msvc.archive .LD  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(linker) /lib /NOLOGO  ;

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1170,7 +1170,7 @@ local rule configure-really ( version ? : options * )
                 }
                 else
                 {
-                    toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(compiler) /Zm800 /ZW -nologo ;
+                    toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(compiler) /Zm800 /ZW /EHsc -nologo ;
                 }
                 toolset.flags msvc.compile .ASM <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(cpu-assembler) -nologo ;
                 toolset.flags msvc.link    .LD  <windows-api>$(api)/$(cpu-conditions) : $(setup-script)$(linker) /NOLOGO /INCREMENTAL:NO ;


### PR DESCRIPTION
there's no /ZW in https://github.com/boostorg/build/blob/develop/src/tools/msvc.jam so both link=shared and link=static are without the Windows namespace and without __cplusplus_winrt. this cause errors like this with both link=shared and link=static

	git clone --depth=1 --no-single-branch http://github.com/boostorg/boost.git .
	git checkout boost-1.57.0
	git submodule update --init
	call "%VS120COMNTOOLS%..\..\vc\vcvarsall.bat" amd64
	bootstrap.bat
	b2 -j8 toolset=msvc-12.0 address-model=64 variant=release,debug link=shared runtime-link=shared windows-api=store
	D:\file\code\lib\boost\boost/asio/detail/buffer_sequence_adapter.hpp(38) : error C2653: 'Windows' : is not a class or namespace name
	D:\file\code\lib\boost\boost/asio/detail/impl/socket_ops.ipp(2246) : error C2871: 'Collections' : a namespace with this name does not exist
	D:\file\code\lib\boost\boost/asio/detail/impl/socket_ops.ipp(2247) : error C2871: 'Networking' : a namespace with this name does not exist

without /ZW there's no Windows namespace or __cplusplus_winrt macro

>https://msdn.microsoft.com/en-us/library/hh561383.aspx

>The required metadata files, **namespaces**, data types, and functions that your app requires to execute in the Windows Runtime.

>http://stackoverflow.com/questions/16698949/how-to-access-namespace-windows

>In the UI, the /ZW option is listed as "Consume Windows Runtime Extension"


## /ZW is recommended but not necessary for WinRT

another solution is to rewrite boostorg/asio to not require /ZW. which would be pointless

the Windows namespace can be accessed with an #include instead of with /ZW

>http://blogs.msdn.com/b/chuckw/archive/2012/09/18/dual-use-coding-techniques-for-games-part-3.aspx

>It is, however, possible to be building for a Windows Store app without the /ZW switch (such as in a static library), so the #ifndef __cplusplus_winrt case can still be for a Windows Store app.

Qt is an example of a lib that doesn't use /ZW. but their reason (code standard and text editor support) is pointless

>http://qt-project.org/wiki/WinRT

>To achieve the best compatibility/consistency with C++ standards as well as support for code editors, only WRL templates [msdn.microsoft.com] should be used when writing platform code for WinRT. No C++/CX extensions should be used.

>https://github.com/qtproject/qtbase/blob/dev/src/winmain/qtmain_winrt.cpp

	#include <wrl.h>
	#include <Windows.ApplicationModel.core.h>

	using namespace ABI::Windows::ApplicationModel;

>https://github.com/qtproject/qtbase/search?p=1&q=%2FZW&type=Code&utf8=%E2%9C%93