### PR TITLE
Typo: supress -> suppress

### DIFF
--- a/doc/src/overview.xml
+++ b/doc/src/overview.xml
@@ -775,7 +775,7 @@ b2 toolset=gcc variant=debug optimization=space
           <varlistentry>
             <term><option>-d0</option></term>
             <listitem>
-              <para>Supress all informational messages.</para>
+              <para>Suppress all informational messages.</para>
             </listitem>
           </varlistentry>
 

--- a/src/util/doc.jam
+++ b/src/util/doc.jam
@@ -264,7 +264,7 @@ local rule print-help-top ( )
     print.list-item "-a Rebuild everything" ;
     print.list-item "-n Don't execute the commands, only print them" ;
     print.list-item "-d+2 Show commands as they are executed" ;
-    print.list-item "-d0 Supress all informational messages" ;
+    print.list-item "-d0 Suppress all informational messages" ;
     print.list-item "-q Stop at first error" ;
     print.list-item "--reconfigure Rerun all configuration checks" ;
     print.list-item "--debug-configuration Diagnose configuration" ;

--- a/test/default_build.py
+++ b/test/default_build.py
@@ -19,7 +19,7 @@ t.run_build_system()
 t.expect_addition("bin/$toolset/debug/a.exe")
 t.expect_addition("bin/$toolset/release/a.exe")
 
-# Check that explictly-specified build variant supresses default-build.
+# Check that explictly-specified build variant suppresses default-build.
 t.rm("bin")
 t.run_build_system(["release"])
 t.expect_addition(BoostBuild.List("bin/$toolset/release/") * "a.exe a.obj")


### PR DESCRIPTION
This fixes typo in documentation etc.