### PR TITLE
gcc.jam mips1 fix

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -451,7 +451,7 @@ rule setup-address-model ( targets * : sources * : properties * )
         else
         {
             local arch = [ feature.get-values architecture : $(properties) ] ;
-            if $(arch) != arm
+            if $(arch) != arm && $(arch) != mips1
             {
                 if $(model) = 32
                 {


### PR DESCRIPTION
  gcc.jam was passing the options -m32 and -m64 to mips cross-compilers, when those do not use such options
  This modification solves it by adding mips1 as an exception.

This issue was causing problems when building MIPS based targets for OpenWRT.
The problem is discussed here: https://github.com/openwrt/packages/issues/1160

Carlos