### PR TITLE
Added targets /boost//log and /boost//log_setup

### DIFF
--- a/src/contrib/boost.jam
+++ b/src/contrib/boost.jam
@@ -213,6 +213,8 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std graph_parallel      : BOOST_GRAPH_DYN_LINK ;
     boost_lib_std iostreams           : BOOST_IOSTREAMS_DYN_LINK ;
     boost_lib_std locale              : BOOST_LOCALE_DYN_LINK ;
+    boost_lib_std log                 : BOOST_LOG_DYN_LINK  ;
+    boost_lib_std log_setup           : BOOST_LOG_SETUP_DYN_LINK  ;
     boost_lib_std math_tr1            : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std math_tr1f           : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std math_tr1l           : BOOST_MATH_TR1_DYN_LINK ;
@@ -234,8 +236,6 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std test_exec_monitor   : BOOST_TEST_DYN_LINK ;
     boost_lib_std thread              : BOOST_THREAD_DYN_DLL  ;
     boost_lib_std wave                : BOOST_WAVE_DYN_LINK  ;
-    boost_lib_std log                 : BOOST_LOG_DYN_LINK  ;
-    boost_lib_std log_setup           : BOOST_LOG_SETUP_DYN_LINK  ;
 }
 
 # Example placeholder for rules defining Boost library project & library targets

--- a/src/contrib/boost.jam
+++ b/src/contrib/boost.jam
@@ -215,27 +215,28 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std locale              : BOOST_LOCALE_DYN_LINK ;
     boost_lib_std log                 : BOOST_LOG_DYN_LINK  ;
     boost_lib_std log_setup           : BOOST_LOG_SETUP_DYN_LINK  ;
-    boost_lib_std math_tr1            : BOOST_MATH_TR1_DYN_LINK ;
-    boost_lib_std math_tr1f           : BOOST_MATH_TR1_DYN_LINK ;
-    boost_lib_std math_tr1l           : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std math_c99            : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std math_c99f           : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std math_c99l           : BOOST_MATH_TR1_DYN_LINK ;
+    boost_lib_std math_tr1            : BOOST_MATH_TR1_DYN_LINK ;
+    boost_lib_std math_tr1f           : BOOST_MATH_TR1_DYN_LINK ;
+    boost_lib_std math_tr1l           : BOOST_MATH_TR1_DYN_LINK ;
     boost_lib_std mpi                 : BOOST_MPI_DYN_LINK  ;
+    boost_lib_std prg_exec_monitor    : BOOST_TEST_DYN_LINK ;
     boost_lib_std program_options     : BOOST_PROGRAM_OPTIONS_DYN_LINK ;
     boost_lib_std python              : BOOST_PYTHON_DYN_LINK ;
     boost_lib_std python3             : BOOST_PYTHON_DYN_LINK ;
     boost_lib_std random              : BOOST_RANDOM_DYN_LINK ;
     boost_lib_std regex               : BOOST_REGEX_DYN_LINK  ;
     boost_lib_std serialization       : BOOST_SERIALIZATION_DYN_LINK ;
-    boost_lib_std wserialization      : BOOST_SERIALIZATION_DYN_LINK ;
     boost_lib_std signals             : BOOST_SIGNALS_DYN_LINK  ;
     boost_lib_std system              : BOOST_SYSTEM_DYN_LINK  ;
-    boost_lib_std unit_test_framework : BOOST_TEST_DYN_LINK  ;
-    boost_lib_std prg_exec_monitor    : BOOST_TEST_DYN_LINK ;
     boost_lib_std test_exec_monitor   : BOOST_TEST_DYN_LINK ;
     boost_lib_std thread              : BOOST_THREAD_DYN_DLL  ;
+    boost_lib_std timer               : BOOST_TIMER_DYN_DLL  ;
+    boost_lib_std unit_test_framework : BOOST_TEST_DYN_LINK  ;
     boost_lib_std wave                : BOOST_WAVE_DYN_LINK  ;
+    boost_lib_std wserialization      : BOOST_SERIALIZATION_DYN_LINK ;
 }
 
 # Example placeholder for rules defining Boost library project & library targets

--- a/src/contrib/boost.jam
+++ b/src/contrib/boost.jam
@@ -234,6 +234,8 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std test_exec_monitor   : BOOST_TEST_DYN_LINK ;
     boost_lib_std thread              : BOOST_THREAD_DYN_DLL  ;
     boost_lib_std wave                : BOOST_WAVE_DYN_LINK  ;
+    boost_lib_std log                 : BOOST_LOG_DYN_LINK  ;
+    boost_lib_std log_setup           : BOOST_LOG_SETUP_DYN_LINK  ;
 }
 
 # Example placeholder for rules defining Boost library project & library targets


### PR DESCRIPTION
In order to link against boost log, I always used to manually add the targets /boost//log and /boost//log_setup, since they are not declared in boost.jam. I was wondering why the library is not supported by boost.build by default. When there is a reason for this, I'm happy to learn about it. Otherwise, the pull request should only be a minor issue.