### PR TITLE
gcc.jam: compiler options fix

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -451,7 +451,7 @@ rule setup-address-model ( targets * : sources * : properties * )
         else
         {
             local arch = [ feature.get-values architecture : $(properties) ] ;
-            if $(arch) != arm && $(arch) != mips1
+            if $(arch) = power || $(arch) = sparc || $(arch) = x86
             {
                 if $(model) = 32
                 {


### PR DESCRIPTION
Only PowerPC, SPARC, and x86 do support the -m32 and -m64 compiler options [1].

Rather then excluding all architectures not supporting these options as it is
done in commit c0634341d9ee2c02d3a55c91dafb988afc066c49, include all architectures that do support them.

This will fix building Boost for the SuperH architecture with Buildroot [2].

[1] https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
[2] http://autobuild.buildroot.net/results/ccd/ccd5c83963032ba49b1627b1dff39e34a9486943/build-end.log