### PR TITLE
use -undefined dynamic_lookup on darwin in python_for_extensions

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -962,15 +962,17 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
     # symbols. If we linked to libpython, we would get duplicate symbols. So
     # declare two targets -- one for building extensions and another for
     # embedding.
-    #
-    # Unlike most *nix systems, Mac OS X's linker does not permit undefined
-    # symbols when linking a shared library. So, we still need to link against
-    # the Python framework, even when building extensions. Note that framework
-    # builds of Python always use shared libraries, so we do not need to worry
-    # about duplicate Python symbols.
-    if $(target-os) in windows cygwin darwin
+    if $(target-os) in windows cygwin
     {
         alias python_for_extensions : python : $(target-requirements) ;
+    }
+    else if $(target-os) = darwin {
+        alias python_for_extensions
+            :
+            : $(target-requirements)
+            :
+            : $(usage-requirements) <linkflags>"-undefined dynamic_lookup"
+            ;
     }
     # On AIX we need Python extensions and Boost.Python to import symbols from
     # the Python interpreter. Dynamic libraries opened with dlopen() do not


### PR DESCRIPTION
Passing -undefined dynamic_lookup to the linker (instead of -lpython or
-framework Python) permits undefined symbols in shared libraries on OS
X. This allows a module to be linked against one Python framework and
imported from another.

Tested by building ledger, which uses Boost.Python, against a version of Boost built with and without this patch. In the "before" gist, libboost_python-mt.dylib has a linkage to `/usr/local/Frameworks/Python.framework/Versions/2.7/Python`; in the "after" gist, it does not, and the ledger python demo still runs correctly. https://gist.github.com/tdsmith/558243ad98ad288a16e0

Closes #69.