### PR TITLE
Allow build.sh to run on solaris 10

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -152,9 +152,9 @@ case $BOOST_JAM_TOOLSET in
     intel-linux)
     which icc >/dev/null 2>&1
     if test $? ; then
-	BOOST_JAM_CC=$(which icc)
+	BOOST_JAM_CC=`which icc`
 	echo "Found $BOOST_JAM_CC in environment"
-	BOOST_JAM_TOOLSET_ROOT=$(echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//')
+	BOOST_JAM_TOOLSET_ROOT=`echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//'`
 	# probably the most widespread
 	ARCH=intel64
     else

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -150,9 +150,9 @@ case $BOOST_JAM_TOOLSET in
     ;;
 
     intel-linux)
-    which icc >/dev/null 2>&1
+    test_path icc >/dev/null 2>&1
     if test $? ; then
-	BOOST_JAM_CC=`which icc`
+	BOOST_JAM_CC=`test_path icc`
 	echo "Found $BOOST_JAM_CC in environment"
 	BOOST_JAM_TOOLSET_ROOT=`echo $BOOST_JAM_CC | sed -e 's/bin.*\/icc//'`
 	# probably the most widespread


### PR DESCRIPTION
This PR contains two fixes for solaris 10. First, it updates some subshell invocations to use `` instead of $(), which is not valid in sh. Second, it replaces two invocations of which with test_path, because which always returns 0 on solaris.