### PR TITLE
Update execnt to take an output callback.

### DIFF
--- a/server/client/index.js
+++ b/server/client/index.js
@@ -707,11 +707,11 @@ var BoostBuildUI = React.createClass({
 
     componentDidMount: function() {
         var self = this;
-        //this.ws = new WebSocket("ws://" + location.host + location.pathname);
-        this.ws = new WebSocket('ws://104.131.124.127:3000')
+        this.ws = new WebSocket("ws://" + location.host + location.pathname);
+        //this.ws = new WebSocket('ws://104.131.124.127:3000')
         this.ws.onmessage = this.handleServerMessage;
         this.ws.onopen = function() {
-            console.log("Connection is now opoen");
+            console.log("Connection is now open");
             self.setState({connection: 'open'});
         }.bind(this);
         this.ws.onerror = function() {

--- a/server/index.js
+++ b/server/index.js
@@ -80,8 +80,15 @@ function talkToB2(ws, b2)
 ws.on('connection', function(ws) {
     console.log("client connected");
 
-    var binary = __dirname + "/../src/engine/bin.linuxx86_64.debug/b2"
-    var example = __dirname + "/../example/libraries"
+    var binary = __dirname;
+    if(process.platform === 'win32'){
+        binary += "/../src/engine/bin.ntx86/b2.exe";
+    }
+    else {
+        binary += "/../src/engine/bin.linuxx86_64.debug/b2";
+    }
+
+    var example = __dirname + "/../example/libraries";
 
     temp.mkdir('libraries', function(err, destination) {
         ncp(example, destination, function (err) {

--- a/src/build/engine.py
+++ b/src/build/engine.py
@@ -41,8 +41,6 @@ class BjamNativeAction:
     be called when this action is installed on any target.
     """
 
-    __re_windows_drive = re.compile(r'^.*:\$')
-
     def __init__(self, action_name, function):
         self.action_name = action_name
         self.function = function
@@ -71,6 +69,8 @@ class Engine:
     target variables like SEARCH and LOCATE make this class coupled
     to bjam engine.
     """
+    __re_windows_drive = re.compile(r'^.*:\$')
+
     def __init__ (self):
         self.actions = {}
         self.mkdir_set = set()

--- a/src/tools/msvc.py
+++ b/src/tools/msvc.py
@@ -331,14 +331,14 @@ class SetupAction:
         self.setup_func = setup_func
         self.function = function
             
-    def __call__(self, targets, sources, property_set):
+    def __call__(self, targets, sources, property_set, callback=None):
         assert(callable(self.setup_func))
         # This can modify sources.
         action_name = self.setup_func(targets, sources, property_set)
         # Bjam actions defined from Python have only the command
         # to execute, and no associated jam procedural code. So
         # passing 'property_set' to it is not necessary.
-        bjam.call("set-update-action", action_name, targets, sources, [])
+        bjam.set_update_action(action_name, targets, sources, [], callback)
         if self.function:
             self.function(targets, sources, property_set)
 
@@ -662,7 +662,7 @@ def configure_really(version=None, options=[]):
         # Mark the configuration as 'used'.
         __versions.use(version)
         # Generate conditions and save them.
-        conditions = common.check_init_parameters('msvc', None, ('version', v))
+        conditions = common.check_init_parameters('msvc', None, [], ('version', v))
         __versions.set(version, 'conditions', conditions)
         command = feature.get_values('<command>', options)
         


### PR DESCRIPTION
This worked with my super simple project in Windows.. I think the usage of the `ioBuffer` should be fine since it looks like Python is going to create a copy of the buffer in the call to `PyString_FromStringAndSize` inside of `make1c_output_closure`. I haven't gotten the client WebSocket demo to work 100% yet, but what I have here should be a good start. Just thought I'd share in case anyone else wants to do some work on Windows.