### PR TITLE
Add missing defines to enable bootstrapping with vc8 toolset.

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -365,7 +365,7 @@ if NOT "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%BOOST_JAM_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
+set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DWINVER=0x0501 -D_WIN32_WINNT=0x0501 -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
 set "BOOST_JAM_OPT_JAM=/Febootstrap\jam0"
 set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
 set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"

--- a/src/engine/builtins.c
+++ b/src/engine/builtins.c
@@ -38,7 +38,19 @@
  */
 #include <winioctl.h>
 #endif
+
+/* With VC8 (VS2005) these are not defined:
+ *   FSCTL_GET_REPARSE_POINT  (expects WINVER >= 0x0500 _WIN32_WINNT >= 0x0500 )
+ *   IO_REPARSE_TAG_SYMLINK   (is part of a separate Driver SDK)
+ * So define them explicitily to their expected values.
+ */
+#ifndef FSCTL_GET_REPARSE_POINT
+# define FSCTL_GET_REPARSE_POINT 0x000900a8
 #endif
+#ifndef IO_REPARSE_TAG_SYMLINK
+# define IO_REPARSE_TAG_SYMLINK	(0xA000000CL)
+#endif
+#endif /* OS_NT */
 
 #if defined(USE_EXECUNIX)
 # include <sys/types.h>
@@ -436,7 +448,7 @@ void load_builtins()
         char const * args [] = { "path", 0 };
         bind_builtin( "MAKEDIR", builtin_makedir, 0, args );
     }
-    
+
     {
         const char * args [] = { "path", 0 };
         bind_builtin( "READLINK", builtin_readlink, 0, args );
@@ -1946,7 +1958,7 @@ LIST *builtin_readlink( FRAME * frame, int flags )
         bufsize *= 2;
         buf = BJAM_MALLOC( bufsize );
     }
-    
+
     if ( buf != static_buf )
         BJAM_FREE( buf );
 


### PR DESCRIPTION
Boost.Build supports bootstrapping and building with VisualStudio 2005 (`bootstrap vc8`). However  when actually attempting the bootstrap, it fails with compile errors:

    builtins.c(1887) : error C2065: 'FSCTL_GET_REPARSE_POINT' : undeclared identifier
    builtins.c(1891) : error C2065: 'IO_REPARSE_TAG_SYMLINK' : undeclared identifier

This patch adds macros needed to properly define theses missing above in the VisualStudio 2005 context. In other contexts the changes should be transparent.
The resulting code successfully completes the bootstrap with VisualStudio 2005 (on Win XP) and passes the `test_all.py` with the same results as the base Boost.Build `develop` revision.