### PR TITLE
Command Line property expansion and Project target loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.pyc
+*.py[cod]
 /doc/bin
 /doc/html
 /b2

--- a/src/build-system.jam
+++ b/src/build-system.jam
@@ -684,10 +684,7 @@ local rule should-clean-project ( project )
     # on the command line) have been loaded.
     if $(properties)
     {
-        for local p in $(properties)
-        {
-            expanded += [ build-request.convert-command-line-element $(p) ] ;
-        }
+        expanded += [ build-request.convert-command-line-elements $(properties) ] ;
         expanded = [ build-request.expand-no-defaults $(expanded) ] ;
         local xexpanded ;
         for local e in $(expanded)

--- a/src/build-system.jam
+++ b/src/build-system.jam
@@ -585,26 +585,6 @@ local rule should-clean-project ( project )
     local properties = [ $(build-request).get-at 2 ] ;
 
 
-    # Expand properties specified on the command line into multiple property
-    # sets consisting of all legal property combinations. Each expanded property
-    # set will be used for a single build run. E.g. if multiple toolsets are
-    # specified then requested targets will be built with each of them.
-    if $(properties)
-    {
-        expanded = [ build-request.expand-no-defaults $(properties) ] ;
-        local xexpanded ;
-        for local e in $(expanded)
-        {
-            xexpanded += [ property-set.create [ feature.split $(e) ] ] ;
-        }
-        expanded = $(xexpanded) ;
-    }
-    else
-    {
-        expanded = [ property-set.empty ] ;
-    }
-
-
     # Check that we actually found something to build.
     if ! $(current-project) && ! $(target-ids)
     {
@@ -694,6 +674,32 @@ local rule should-clean-project ( project )
     local first-build-build-dir = [ $(first-project-root).build-dir ] ;
     configure.set-log-file $(first-build-build-dir)/config.log ;
     config-cache.load $(first-build-build-dir)/project-cache.jam ;
+
+    # Expand properties specified on the command line into multiple property
+    # sets consisting of all legal property combinations. Each expanded property
+    # set will be used for a single build run. E.g. if multiple toolsets are
+    # specified then requested targets will be built with each of them.
+    # The expansion is being performed as late as possible so that the feature
+    # validation is performed after all necessary modules (including project targets
+    # on the command line) have been loaded.
+    if $(properties)
+    {
+        for local p in $(properties)
+        {
+            expanded += [ build-request.convert-command-line-element $(p) ] ;
+        }
+        expanded = [ build-request.expand-no-defaults $(expanded) ] ;
+        local xexpanded ;
+        for local e in $(expanded)
+        {
+            xexpanded += [ property-set.create [ feature.split $(e) ] ] ;
+        }
+        expanded = $(xexpanded) ;
+    }
+    else
+    {
+        expanded = [ property-set.empty ] ;
+    }
 
     # Now that we have a set of targets to build and a set of property sets to
     # build the targets with, we can start the main build process by using each

--- a/src/build/build-request.jam
+++ b/src/build/build-request.jam
@@ -168,10 +168,23 @@ rule from-command-line ( command-line * )
 }
 
 
-# Converts one element of command line build request specification into internal
+# Converts a list of elements of command line build request specification into internal
 # form. Expects all the project files to already be loaded.
 #
-rule convert-command-line-element ( e )
+rule convert-command-line-elements ( elements * )
+{
+    local result ;
+    for local e in $(elements)
+    {
+        result += [ convert-command-line-element $(e) ] ;
+    }
+    return $(result) ;
+}
+
+
+# Converts one element of command line build request specification into internal
+# form.
+local rule convert-command-line-element ( e )
 {
     local result ;
     local parts = [ regex.split $(e) "/" ] ;
@@ -285,37 +298,60 @@ rule __test__ ( )
 
     local r ;
 
-    r = [ build-request.from-command-line bjam debug runtime-link=dynamic ] ;
-    assert.equal [ $(r).get-at 1 ] : ;
-    assert.equal [ $(r).get-at 2 ] : debug <runtime-link>dynamic ;
-
     try ;
     {
-        build-request.from-command-line bjam gcc/debug runtime-link=dynamic/static ;
+        r = [ build-request.from-command-line bjam gcc/debug runtime-link=dynamic/static ] ;
+        build-request.convert-command-line-elements [ $(r).get-at 2 ] ;
     }
     catch \"static\" is not an implicit feature value ;
 
+    r = [ build-request.from-command-line bjam debug runtime-link=dynamic ] ;
+    assert.equal [ $(r).get-at 1 ] : ;
+    assert.equal [ $(r).get-at 2 ] : debug runtime-link=dynamic ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements debug runtime-link=dynamic ]
+        : debug <runtime-link>dynamic ;
+
     r = [ build-request.from-command-line bjam -d2 --debug debug target runtime-link=dynamic ] ;
     assert.equal [ $(r).get-at 1 ] : target ;
-    assert.equal [ $(r).get-at 2 ] : debug <runtime-link>dynamic ;
+    assert.equal [ $(r).get-at 2 ] : debug runtime-link=dynamic ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements debug runtime-link=dynamic ]
+        : debug <runtime-link>dynamic ;
 
     r = [ build-request.from-command-line bjam debug runtime-link=dynamic,static ] ;
     assert.equal [ $(r).get-at 1 ] : ;
-    assert.equal [ $(r).get-at 2 ] : debug <runtime-link>dynamic <runtime-link>static ;
+    assert.equal [ $(r).get-at 2 ] : debug runtime-link=dynamic,static ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements debug runtime-link=dynamic,static ]
+        : debug <runtime-link>dynamic <runtime-link>static ;
 
     r = [ build-request.from-command-line bjam debug gcc/runtime-link=dynamic,static ] ;
     assert.equal [ $(r).get-at 1 ] : ;
-    assert.equal [ $(r).get-at 2 ] : debug gcc/<runtime-link>dynamic
-        gcc/<runtime-link>static ;
+    assert.equal [ $(r).get-at 2 ] : debug gcc/runtime-link=dynamic,static ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements debug gcc/runtime-link=dynamic,static ]
+        : debug gcc/<runtime-link>dynamic gcc/<runtime-link>static ;
 
     r = [ build-request.from-command-line bjam msvc gcc,borland/runtime-link=static ] ;
     assert.equal [ $(r).get-at 1 ] : ;
-    assert.equal [ $(r).get-at 2 ] : msvc gcc/<runtime-link>static
-        borland/<runtime-link>static ;
+    assert.equal [ $(r).get-at 2 ] : msvc gcc,borland/runtime-link=static ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements msvc gcc,borland/runtime-link=static ]
+        : msvc gcc/<runtime-link>static borland/<runtime-link>static ;
 
     r = [ build-request.from-command-line bjam gcc-3.0 ] ;
     assert.equal [ $(r).get-at 1 ] : ;
     assert.equal [ $(r).get-at 2 ] : gcc-3.0 ;
+
+    assert.equal
+        [ build-request.convert-command-line-elements gcc-3.0 ]
+        : gcc-3.0 ;
 
     feature.finish-test build-request-test-temp ;
 }

--- a/src/build/build-request.jam
+++ b/src/build/build-request.jam
@@ -150,8 +150,7 @@ rule from-command-line ( command-line * )
             if [ MATCH "(.*=.*)" : $(e) ]
                 || [ looks-like-implicit-value $(e:D=) : $(feature-space) ]
             {
-                properties += [ convert-command-line-element $(e) :
-                    $(feature-space) ] ;
+                properties += $(e) ;
             }
             else if $(e)
             {
@@ -172,7 +171,7 @@ rule from-command-line ( command-line * )
 # Converts one element of command line build request specification into internal
 # form. Expects all the project files to already be loaded.
 #
-local rule convert-command-line-element ( e )
+rule convert-command-line-element ( e )
 {
     local result ;
     local parts = [ regex.split $(e) "/" ] ;

--- a/src/build/build_request.py
+++ b/src/build/build_request.py
@@ -119,7 +119,7 @@ def from_command_line(command_line):
             # Build request spec either has "=" in it, or completely
             # consists of implicit feature values.
             if e.find("=") != -1 or looks_like_implicit_value(e.split("/")[0]):
-                properties += convert_command_line_element(e)
+                properties.append(e)
             elif e:
                 targets.append(e)
 

--- a/src/build_system.py
+++ b/src/build_system.py
@@ -509,15 +509,6 @@ def main_real():
     # that all project files already be loaded.
     (target_ids, properties) = build_request.from_command_line(sys.argv[1:] + extra_properties)
 
-    # Expand properties specified on the command line into multiple property
-    # sets consisting of all legal property combinations. Each expanded property
-    # set will be used for a single build run. E.g. if multiple toolsets are
-    # specified then requested targets will be built with each of them.
-    if properties:
-        expanded = build_request.expand_no_defaults(properties)
-    else:
-        expanded = [property_set.empty()]
-
     # Check that we actually found something to build.
     if not current_project and not target_ids:
         get_manager().errors()("no Jamfile in current directory found, and no target references specified.")
@@ -594,6 +585,22 @@ def main_real():
     virtual_targets = []
 
     global results_of_main_targets
+
+    # Expand properties specified on the command line into multiple property
+    # sets consisting of all legal property combinations. Each expanded property
+    # set will be used for a single build run. E.g. if multiple toolsets are
+    # specified then requested targets will be built with each of them.
+    # The expansion is being performed as late as possible so that the feature
+    # validation is performed after all necessary modules (including project targets
+    # on the command line) have been loaded.
+    if properties:
+        expanded = []
+        for p in properties:
+            expanded.extend(build_request.convert_command_line_element(p))
+
+        expanded = build_request.expand_no_defaults(expanded)
+    else:
+        expanded = [property_set.empty()]
 
     # Now that we have a set of targets to build and a set of property sets to
     # build the targets with, we can start the main build process by using each

--- a/test/cli_property_expansion.py
+++ b/test/cli_property_expansion.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+
+# Copyright 2015 Aaron Boman
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+
+# Test that free property inside.
+
+import BoostBuild
+
+t = BoostBuild.Tester(use_test_config=False)
+t.toolset = 'msvc'
+
+t.write("jamroot.jam", "")
+t.write(
+    "subdir/build.jam",
+    """
+    import feature ;
+    feature.feature my-feature : : free ;
+    """
+)
+t.write(
+    "subdir/subsubdir/build.jam",
+    """
+    exe hello : hello.c ;
+    """
+)
+t.write(
+    "subdir/subsubdir/hello.c",
+    r"""
+    #include <stdio.h>
+
+    int main(int argc, char **argv){
+        printf("%s\n", "Hello, World!");
+    }
+    """
+)
+
+# run from the root directory
+t.run_build_system(['subdir/subsubdir', 'my-feature="some value"'])
+
+t.cleanup()

--- a/test/cli_property_expansion.py
+++ b/test/cli_property_expansion.py
@@ -9,7 +9,6 @@
 import BoostBuild
 
 t = BoostBuild.Tester(use_test_config=False)
-t.toolset = 'msvc'
 
 t.write("jamroot.jam", "")
 t.write(


### PR DESCRIPTION
**tl;dr** have a look at the included test to see the scenario.

Assume there are three jamfiles: `Jamroot.jam`, `subdir/build.jam`, and `subdir/subsubdir/build.jam` where each file is a parent to the following. 

Assume that I have a feature declared in `subdir/build.jam`:

```
import feature ;
feature.feature my-feature : : free ;
```

And assume that I have some target to build in the grandchild jamfile, `subdir/subsubdir/build.jam`

```
exe hello : hello.c ;
```

If I try building that target from the root while also specifying the feature declared in `subdir/build.jam`, I will get a feature validation error:

```
$ b2 subdir/subsubdir my-feature="some free value"
error: unknown feature "<my-feature>"
C:/boost-build/src/share/boost-build/src/build\feature.jam:359: in expand-subfeatures-aux from module feature
C:/boost-build/src/share/boost-build/src/build\feature.jam:424: in feature.expand-subfeatures from module feature
C:/boost-build/src/share/boost-build/src/build\build-request.jam:20: in apply-to-property-set from module build-request
(builtin):-1: in sequence.transform from module sequence
C:/boost-build/src/share/boost-build/src/build\build-request.jam:32: in build-request.expand-no-defaults from
module build-request
C:/boost-build/src/share/boost-build/src\build-system.jam:594: in load from module build-system
C:/boost-build\src\share\boost-build\src\kernel\modules.jam:289: in import from module modules
C:/boost-build\src\share\boost-build\src\kernel\bootstrap.jam:139: in boost-build from module
C:/boost-build\src\share\boost-build\boost-build.jam:8: in module scope from module
```

This change delays the property validation and expansion as late as possible to ensure that all projects/modules have been loaded.