### PR TITLE
python: Determine the version if interp, incl & lib are provided

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -736,7 +736,7 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
     local fallback-version ;
 
     # Anything left to find or check?
-    if ! ( $(interpreter-cmd) && $(includes) && $(libraries) )
+    if ! ( $(interpreter-cmd) && $(version) && $(includes) && $(libraries) )
     {
         # Values to be extracted from python's sys module. These will be set by
         # the probe rule, above, using Jam's dynamic scoping.


### PR DESCRIPTION
Fix the conditional around acquiring the data from Python interpreter to be run if interpreter-cmd, includes and libraries are provided (but version is not).