### PR TITLE
Solaris Studio C++11 link errors

### DIFF
--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -148,11 +148,15 @@ actions link bind LIBRARIES
 rule link.dll ( targets * : sources * : properties * )
 {
     SPACE on $(targets) = " " ;
+    if [ MATCH "(-std=c\\+\\+[03,11])" : [ on $(targets) return $(OPTIONS) ] ]
+    {
+       STDLIBOPT on $(targets) = -library=stdcpp,CrunG3 ;
+    }
 }
 
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" -h$(<[1]:D=) -G "$(>)" "$(LIBRARIES)" -Bdynamic -l$(FINDLIBS-SA) -Bstatic -l$(FINDLIBS-ST) -B$(LINK-RUNTIME)
+    "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" -h$(<[1]:D=) -G $(STDLIBOPT) "$(>)" "$(LIBRARIES)" -Bdynamic -l$(FINDLIBS-SA) -Bstatic -l$(FINDLIBS-ST) -B$(LINK-RUNTIME)
 }
 
 # Declare action for creating static libraries


### PR DESCRIPTION
Several python tests fail with the following error message when compiling with Oracle Solaris Studio compilers with -std=[c++03,c++11], modes.

 ImportError?: ld.so.1: isapython2.6: fatal: relocation error: file /export/home/boost_regression_develop/boost_sparc-S2_cpp11/results/boost/bin.v2/libs/python/test/injected.test/sun-next_cpp11/ release/threading-multi/injected_ext.so: symbol _ZTIv: referenced symbol not found

These errors occur when any libraries that are linked into the application that has no C++11 runtime already linked in.

When creating shared libraries, replacing '-G' with '-G -library=stdcpp,CrunG3'   seems to resolve the issue.
