### PR TITLE
Test with both gcc and clang on Linux with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 os:
   - linux
-language: c
-compiler:
-  - gcc
-  - clang
+env:
+  - TOOLSET=gcc
+  - TOOLSET=clang
 script:
-  - ./bootstrap.sh --with-toolset=${CC}
+  - ./bootstrap.sh --with-toolset=${TOOLSET}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ language: c
 compiler:
   - gcc
 script:
-  - ./bootstrap.sh
+  - ./bootstrap.sh --with-toolset=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: c
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ sudo: false
 language: c
 compiler:
   - gcc
-script: ./bootstrap.sh
+script:
+  - ./bootstrap.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+os:
+  - linux
 language: c
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ os:
 language: c
 compiler:
   - gcc
+  - clang
 script:
   - ./bootstrap.sh --with-toolset=${CC}


### PR DESCRIPTION
This does several very minor things and has no effect on the released version of Boost.Build at all.

- use the container infrastructure for speed (sudo: false)
- builds with both gcc and clang under Linux only

This is in preparation for several other ideas enumerated below, which depend on this change.  These are not part of this change since they each have an issue that will need resolving before merging.

- build on OS X (see https://github.com/tee3/build/tree/develop-travis-ci-osx)
   - this will fail due to an issue in Travis CI OS X Python support
- run the Python test suite (see https://github.com/tee3/build/tree/develop-travis-ci-python-tests)
   - this fails **2** tests when Boost.Jam is built with `gcc`
   - this fails **1** tests when Boost.Jam is build with `clang`
