### PR TITLE
Run tests via Travis CI on OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 sudo: false
 os:
   - linux
+  - osx
 env:
   - TOOLSET=gcc
+  - TOOLSET=darwin
   - TOOLSET=clang
+matrix:
+  exclude:
+    - os: linux
+      env: TOOLSET=darwin
+    - os: osx
+      env: TOOLSET=gcc
 script:
   - ./bootstrap.sh --with-toolset=${TOOLSET}


### PR DESCRIPTION
This pull request runs the tests on OS X via Travis CI.  The tests are now passing.

See https://github.com/boostorg/build/pull/110 for initial discussion of this branch.  The issues Travis CI had previously are no longer an issue for building the Boost.Build engine under Travis CI's OS X support.
