### PR TITLE
Run Boost.Build tests via Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ sudo: false
 os:
   - linux
 env:
-  - TOOLSET=gcc
-  - TOOLSET=clang
+  - TOOLSET=gcc TEST_ALL_EXTRAS=
+#  - TOOLSET=gcc TEST_ALL_EXTRAS=--extras
+  - TOOLSET=clang TEST_ALL_EXTRAS=
+#  - TOOLSET=clang TEST_ALL_EXTRAS=--extras
+language: python
+python:
+  - 2.6
 script:
   - ./bootstrap.sh --with-toolset=${TOOLSET}
+  - cd test && python test_all.py ${TOOLSET} ${TEST_ALL_EXTRAS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 #  - TOOLSET=clang TEST_ALL_EXTRAS=--extras
 language: python
 python:
+  - 2.7
   - 2.6
 script:
   - ./bootstrap.sh --with-toolset=${TOOLSET}

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -124,6 +124,9 @@ def run_tests(critical_tests, other_tests):
         FAIL: %d
         """ % (pass_count, failures_count)
 
+    # exit with failure with failures
+    if failures_count > 0:
+        sys.exit(1)
 
 def last_failed_test():
     "Returns the name of the last failed test or None."


### PR DESCRIPTION
This pull request enables running the Boost.Build automated tests (with Python) via Travis CI.  Note that this is currently failing and this pull request does not address the cause of the failures.  These should probably be resolved prior to merging this pull request.  Unfortunately, I don't have the expertise to actually fix the issues with any confidence.

This pull request runs the automated tests for Boost.Build by running `python test_all.py` against each toolset.  It does not run the tests enabled via the `--extras` flag since the requirements for these tests are not met by the Travis CI infrastructure.

When building `b2` with `gcc`, there are two errors with both Python 2.6 and Python 2.7

- [ ] path_features
- [ ] library_order

When building `b2` with `clang`, there is on error with both Python 2.6 and Python 2.7

- [ ] path_features

See https://github.com/boostorg/build/pull/110 for the original description of this branch.
