### PR TITLE
Fix NumPy detection bug in numpy-test.

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -1276,10 +1276,7 @@ rule numpy-test ( name : sources * : requirements * )
 {
     numpy-include = [ python.numpy-include ] ;
     # yuk !
-    if $(.numpy) = false
-    {
-      requirements += <build>no ;
-    }
+    if ! $(.numpy) { requirements += <build>no ; }
     sources ?= $(name).py $(name).cpp ;
     name = [ regex.replace $(name) "[/]" "~" ] ;
     return [ testing.make-test run-pyd


### PR DESCRIPTION
This fixes a bug whereby on test runs that don't have NumPy installed the tests would be (attempted to be) executed anyhow (and fail). With this, the NumPy tests will simply be skipped.