### PR TITLE
Do not reuse the same target for different library link checks

### DIFF
--- a/src/build/ac.jam
+++ b/src/build/ac.jam
@@ -76,14 +76,6 @@ rule construct-library ( name : property-set : provided-path ? )
 rule find-library ( properties : names + : provided-path ? )
 {
     local result ;
-    if ! $(.main.cpp)
-    {
-        local a = [ class.new action : ac.generate-main :
-                    [ property-set.empty ] ] ;
-        .main.cpp = [ virtual-target.register
-            [ class.new file-target main.cpp exact
-                : CPP : $(.project) : $(a) ] ] ;
-    }
     if [ $(properties).get <link> ] = shared
     {
         link-opts = <link>shared <link>static ;
@@ -100,8 +92,12 @@ rule find-library ( properties : names + : provided-path ? )
         {
             local name = $(names-iter[1]) ;
             local lib = [ construct-library $(name) : $(properties) : $(provided-path) ] ;
+            local a = [ class.new action : ac.generate-main :
+                [ property-set.empty ] ] ;
+            local main.cpp = [ virtual-target.register
+                [ class.new file-target main-$(name).cpp exact : CPP : $(.project) : $(a) ] ] ;
             local test = [ generators.construct $(.project) $(name) : EXE
-                : [ $(properties).add $(lib[1]) ] : $(.main.cpp) $(lib[2-])
+                : [ $(properties).add $(lib[1]) ] : $(main.cpp) $(lib[2-])
                 : true ] ;
             local jam-targets ;
             for t in $(test[2-])


### PR DESCRIPTION
Using a global .main.cpp target causes conflicts when testing for libraries in different directories.
For example, trying to build boost.iostreams with
```
$(BUILD)/b2 -q \
   -d$(DEBUG) \
   -sBZIP2_INCLUDE=../bzip2-1.0.6 \
   -sBZIP2_LIBPATH=../bzip2-1.0.6 \
   -sZLIB_INCLUDE=../zlib-1.2.10 \
   -sZLIB_LIBPATH=../zlib-1.2.10 \
   --build-dir=build \
   --stage-dir=stage \
   toolset=gcc \
   link=shared \
   threading=multi \
   variant=release \
   cxxflags="-std=c++11 -O2" \
   stage
```
results in
```
error: at /home/fwyzard/src/boost/boost_1_63_0/tools/build/src/kernel/modules.jam:107
error: Name clash for '<pbuild/boost/bin.v2/standalone/ac/gcc-5.4.1/release/threading-multi>main.o'
error: 
error: Tried to build the target twice, with property sets having 
error: these incompatible properties:
error: 
error:     -  <dll-path>../zlib-1.2.10 <library-path>../zlib-1.2.10 <xdll-path>../zlib-1.2.10
error:     -  <dll-path>../bzip2-1.0.6 <library-path>../bzip2-1.0.6 <xdll-path>../bzip2-1.0.6
error: 
error: Please make sure to have consistent requirements for these 
error: properties everywhere in your project, especially for install
error: targets.
```

Using a different target for each check solves the issue.