### PR TITLE
Fix generating pre-compiled headers (pch) with clang (on linux).

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -153,7 +153,7 @@ rule compile.c++.pch ( targets * : sources * : properties * ) {
 }
 
 actions compile.c++.pch {
-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
 }
 
 rule compile.c.pch ( targets * : sources * : properties * ) {
@@ -164,7 +164,7 @@ rule compile.c.pch ( targets * : sources * : properties * ) {
 
 actions compile.c.pch
 {
-  rm -f "$(<)" && "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+  rm -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
 }
 
 ###############################################################################


### PR DESCRIPTION
This fixes generating pre-compiled headers (pch) with clang (on linux).

See this conversation on the boost-users mailing-list: http://lists.boost.org/boost-users/2017/01/87080.php