### PR TITLE
Fixed paths for vc15 and arch variable

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -106,19 +106,19 @@ if NOT "_%VS150COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"
     goto :eof)
 call :Clear_Error
-if EXIST "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  (
+if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  (
     set "BOOST_JAM_TOOLSET=vc15"
-    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\VC\"
+    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFilesi(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\"
     goto :eof)
 call :Clear_Error
-if EXIST "%ProgramFiles%\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat"  (
+if EXIST "%ProgramFilesi(x86)%\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat"  (
     set "BOOST_JAM_TOOLSET=vc15"
-    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFiles%\Microsoft Visual Studio\2017\Professional\VC\"
+    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFilesi(x86)%\Microsoft Visual Studio\2017\Professional\VC\"
     goto :eof)
 call :Clear_Error
-if EXIST "%ProgramFiles%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"  (
+if EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"  (
     set "BOOST_JAM_TOOLSET=vc15"
-    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFiles%\Microsoft Visual Studio\2017\Community\VC\"
+    set "BOOST_JAM_TOOLSET_ROOT=%ProgramFilesi(x86)%\Microsoft Visual Studio\2017\Community\VC\"
     goto :eof)
 call :Clear_Error
 if NOT "_%VS140COMNTOOLS%_" == "__" (
@@ -470,6 +470,13 @@ if NOT "_%BOOST_JAM_TOOLSET%_" == "_vc15_" goto Skip_VC15
 if NOT "_%VS150COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"
     )
+
+REM vc15 vsvarsall requires the architecture as a parameter.
+set BOOST_JAM_ARCH=x86
+if NOT "_%PROCESSOR_ARCHITECTURE%_" == "__" set BOOST_JAM_ARCH=%PROCESSOR_ARCHITECTURE%
+if NOT "_%Platform%_" == "__" set BOOST_JAM_ARCH=%Platform%
+set BOOST_JAM_ARGS=%BOOST_JAM_ARGS% %BOOST_JAM_ARCH%
+
 if "_%VCINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %BOOST_JAM_ARGS%
 if NOT "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (


### PR DESCRIPTION
I had some problems when my tester with Visual Studio 2017 RC (msvc-15.0) installed pulled the boost build commit that included merge #158. 

Specifically, the default install path for msvc-15.0 is `C:\Program Files (x86)\...` so if we are going to use the paths to determine if it is installed (that is super dangerous!) we should use the `%ProgramFiles(x86)%` env variable. When building on a 32-bit system (or from a 32-bit command prompt like you get when python 32-bit calls `os.system('build.bat')`) that variable with simply point to the same location as `%ProgramFiles%`, so I'd argue it is better to use this.

Then there was an issue with the call to `vsvarsall.bat`, which in msvc-15.0 has a required first argument of the architecture. I'm not sure if there is a canonical boost  build way to pick a default architecture...so I start with x86, then use the `%PROCESSOR_ARCHTECTURE%` variable to upgrade to amd64 for most users. However if the user's environment includes the  `%Platform%` variable, it will override the others...as this is what microsoft sets up when they are doing cross-compiling (e.g. amd64 -> x86). 