### PR TITLE
Fixed setting of SONAME for toolset qcc

### DIFF
--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -234,5 +234,5 @@ rule link.dll ( targets * : sources * : properties * )
 #
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,-R$(SPACE)-Wl,"$(RPATH)" -o "$(<)" $(HAVE_SONAME)-Wl,-h$(SPACE)-Wl,$(<[1]:D=) -shared "$(>)"  "$(LIBRARIES)" -l$(FINDLIBS-ST) -l$(FINDLIBS-SA) $(OPTIONS)
+    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,-R$(SPACE)-Wl,"$(RPATH)" -o "$(<)" -Wl,-h$(SPACE)-Wl,$(<[1]:D=) -shared "$(>)"  "$(LIBRARIES)" -l$(FINDLIBS-ST) -l$(FINDLIBS-SA) $(OPTIONS)
 }


### PR DESCRIPTION
The SONAME is now set unconditionally. The use if HAVE_SONAME was probably mistakenly copied from gcc.jam.

Without this, dlls didn't work unless they were in the same path they were compiled. Fixes #85 and https://svn.boost.org/trac/boost/ticket/10227.

My test runner NA-QNX660-x86 is currently running with this fix.