### PR TITLE
cygwin-to-windows-path accepts full windows path

### DIFF
--- a/src/tools/cygwin.jam
+++ b/src/tools/cygwin.jam
@@ -60,7 +60,7 @@ rule cygwin-to-windows-path ( path )
             }
             tail = $(tail:R=$(head:D=)) ;
 
-            if $(head) = /
+            if $(head) = "/" || [ MATCH  "^([a-zA-Z]:/)$" : $(head) ]
             {
                 head = ;
             }


### PR DESCRIPTION
Please check the detailed description: https://svn.boost.org/trac/boost/ticket/12711

