### PR TITLE
Documentation covering multiple flags and multiple variants in user-c…

### DIFF
--- a/doc/src/overview.xml
+++ b/doc/src/overview.xml
@@ -526,6 +526,9 @@ using msvc : : echo Compiling &#x26;&#x26; foo/bar/baz/cl ;
 using gcc : 3.3 ;
 using gcc : 3.4 : g++-3.4 ;
 using gcc : 3.2 : g++-3.2 ;
+using gcc : 5 ;
+using clang : 3.9 ;
+using msvc : 14.0 ;
 </programlisting>
       Note that in the first call to <code language="jam">using</code>, the
       compiler found in the <envar>PATH</envar> will be used, and there is no
@@ -555,7 +558,8 @@ using gcc : 3.4 : g++-3.4 ;
       <varname>cflags</varname>, <varname>cxxflags</varname>,
       <varname>compileflags</varname> and <varname>linkflags</varname> as <parameter
       class="function">options</parameter> specifying flags that will be
-      always passed to the corresponding tools. Values of the
+      always passed to the corresponding tools. There must not be a space
+      between the tag for the option name and the value. Values of the
       <varname>cflags</varname> feature are passed directly to the C
       compiler, values of the <varname>cxxflags</varname> feature are
       passed directly to the C++ compiler, and values of the
@@ -563,7 +567,37 @@ using gcc : 3.4 : g++-3.4 ;
       example, to configure a <command>gcc</command> toolset so that it
       always generates 64-bit code you could write:
 <programlisting>
-        using gcc : 3.4 : : &lt;compileflags&gt;-m64 &lt;linkflags&gt;-m64 ;
+using gcc : 3.4 : : &lt;compileflags&gt;-m64 &lt;linkflags&gt;-m64 ;
+</programlisting>
+    </para>
+
+    <para>
+      If multiple of the same type of options are needed, they can be
+      concatenated with quotes or have multiple instances of the option tag.
+<programlisting>
+using gcc : 5 : : &lt;cxxflags&gt;"-std=c++14 -O2" ;
+using clang : 3.9 : : &lt;cxxflags&gt;-std=c++14 &lt;cxxflags&gt;-O2 ;
+</programlisting>
+    </para>
+
+    <para>
+      Multiple varaiations of the same tool can be used for most tools. 
+      These are deliniated by the version passed in. Because the dash '-'
+      cannot be used here, the convention has become to use the tilde '~' to
+      deliniate variations.
+
+<programlisting>
+using gcc : 5 : g++-5 : ; # default is C++ 98
+using gcc : 5~c++03 : g++-5 : &lt;cxxflags&gt;-std=c++03 ; # C++ 03
+using gcc : 5~gnu03 : g++-5 : &lt;cxxflags&gt;-std=gnu++03 ; # C++ 03 with GNU
+using gcc : 5~c++11 : g++-5 : &lt;cxxflags&gt;-std=c++11 ; # C++ 11
+using gcc : 5~c++14 : g++-5 : &lt;cxxflags&gt;-std=c++14 ; # C++ 14
+</programlisting>
+
+      These are then used as normal toolsets:
+<programlisting>
+b2 toolset=gcc-5 stage
+b2 toolset=gcc-5~c++14 stage
 </programlisting>
     </para>
 


### PR DESCRIPTION
…onfig.jam

This details how you can have multiple options for a tag e.g. `<cxxflags>"-std=c++14 -O2"` and how you can make multiple variations of a version config.

I think I've put it in correctly, but I don't have the toolchain to actually build the docs and see what they look like. Can someone who does have the toolchain try that before this is merged?