### PR TITLE
ci: Enable DO_DIFF on travis-ci to facilitate debugging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 os:
   - linux
 env:
-  - TOOLSET=gcc TEST_ALL_EXTRAS= DO_DIFF=1
+  - TOOLSET=gcc TEST_ALL_EXTRAS=
 #  - TOOLSET=gcc TEST_ALL_EXTRAS=--extras
-  - TOOLSET=clang TEST_ALL_EXTRAS= DO_DIFF=1
+  - TOOLSET=clang TEST_ALL_EXTRAS=
 #  - TOOLSET=clang TEST_ALL_EXTRAS=--extras
 language: python
 python:
@@ -12,4 +12,4 @@ python:
   - 2.6
 script:
   - ./bootstrap.sh --with-toolset=${TOOLSET}
-  - cd test && python test_all.py ${TOOLSET} ${TEST_ALL_EXTRAS}
+  - cd test && DO_DIFF=1 python test_all.py ${TOOLSET} ${TEST_ALL_EXTRAS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 os:
   - linux
 env:
-  - TOOLSET=gcc TEST_ALL_EXTRAS=
+  - TOOLSET=gcc TEST_ALL_EXTRAS= DO_DIFF=1
 #  - TOOLSET=gcc TEST_ALL_EXTRAS=--extras
-  - TOOLSET=clang TEST_ALL_EXTRAS=
+  - TOOLSET=clang TEST_ALL_EXTRAS= DO_DIFF=1
 #  - TOOLSET=clang TEST_ALL_EXTRAS=--extras
 language: python
 python:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,4 +22,5 @@ build_script:
 
 test_script:
   - cd test
+  - set DO_DIFF=1
   - python test_all.py msvc %TEST_ALL_EXTRAS% --preserve


### PR DESCRIPTION
The Boost.Build tests provide a mechanism to observe the difference between the expected output of a test and the output of a failing test.  This is useful in a CI context because it is time-consuming to resolve issues that occur only on the cloud-based CI system.

I don't believe that this will cause issues due to large prints as most tests succeed and print nothing.  It is only when a test fails does this print anything and this should be rare for CI.  Furthermore, I believe that most tests do not typically print out large chunks of text when running.

This has passed the testing on travis-ci on a local branch.
