### PR TITLE
Implement a pseudo-toolset for cross-compiling

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -39,6 +39,12 @@ error_exit ()
     echo "### detected. The 'cc' toolset will use the CC, CFLAGS, and LIBS"
     echo "### environment variables, if present."
     echo "###"
+    echo "### Similarly, the cross-cc toolset is available for cross-compiling"
+    echo "### by using the BUILD_CC, BUILD_CFLAGS, and BUILD_LDFLAGS environment"
+    echo "### variables to compile binaries that will be executed on the build"
+    echo "### system. This allows CC etc. to be set for cross-compilers to be"
+    echo "### propagated to subprocesses."
+    echo "###"
     exit 1
 }
 
@@ -264,6 +270,15 @@ case $BOOST_JAM_TOOLSET in
     BOOST_JAM_OPT_JAM="$BOOST_JAM_OPT_JAM $CFLAGS $LIBS"
     BOOST_JAM_OPT_MKJAMBASE="$BOOST_JAM_OPT_MKJAMBASE $CFLAGS $LIBS"
     BOOST_JAM_OPT_YYACC="$BOOST_JAM_OPT_YYACC $CFLAGS $LIBS"
+    ;;
+
+    cross-cc)
+    if test -z "$BUILD_CC" ; then BUILD_CC=cc ; fi
+    BOOST_JAM_CC=$BUILD_CC
+    BOOST_JAM_OPT_JAM="$BOOST_JAM_OPT_JAM $BUILD_CFLAGS $BUILD_LDFLAGS"
+    BOOST_JAM_OPT_MKJAMBASE="$BOOST_JAM_OPT_MKJAMBASE $BUILD_CFLAGS $BUILD_LDFLAGS"
+    BOOST_JAM_OPT_YYACC="$BOOST_JAM_OPT_YYACC $BUILD_CFLAGS $BUILD_LDFLAGS"
+    BOOST_JAM_TOOLSET=cc
     ;;
 
     qcc)


### PR DESCRIPTION
I didn't see a way to use the bootstrapping binaries while cross-compiling with the `cc` toolset.  Am I missing something?  If not, here is a patch that adds the option.  It supports building native bootstrapping binaries and cross-compiling everything else.