### PR TITLE
Add support for Markdown in doxygen target.

### DIFF
--- a/src/tools/doxygen.jam
+++ b/src/tools/doxygen.jam
@@ -100,7 +100,7 @@ rule init ( name ? )
         .doxproc = $(.doxproc:D)/doxproc.py ;
 
         generators.register-composing doxygen.headers-to-doxyfile
-            : H HPP CPP : DOXYFILE ;
+            : H HPP CPP MARKDOWN : DOXYFILE ;
         generators.register-standard doxygen.run
             : DOXYFILE : DOXYGEN_XML_MULTIFILE ;
         generators.register-standard doxygen.xml-dir-to-boostbook

--- a/src/tools/types/markdown.jam
+++ b/src/tools/types/markdown.jam
@@ -1,4 +1,4 @@
 # Copyright David Abrahams 2004. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-type MARKDOWN : markdown md ;
+type MARKDOWN : md markdown ;

--- a/src/tools/types/markdown.jam
+++ b/src/tools/types/markdown.jam
@@ -1,0 +1,4 @@
+# Copyright David Abrahams 2004. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+type MARKDOWN : markdown md ;

--- a/src/tools/types/markdown.py
+++ b/src/tools/types/markdown.py
@@ -1,0 +1,10 @@
+# Copyright David Abrahams 2004. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from b2.build import type
+
+def register ():
+    type.register_type ('MARKDOWN', ['markdown', 'md'])
+
+register ()


### PR DESCRIPTION
This change adds support for Markdown in `doxygen`.

* Adds a type `MARKDOWN` for Markdown files, with extension `.markdown` or `.md`.  This change could probably stand on its own as Markdown is a pretty standard file type now.

* Allows Markdown files to be included in the source list for `doxygen` targets.  This should have the effect of using all the Markdown files in the list as input to Doxygen.  The user is responsible for making sure that the Markdown fits in to Doxygen.

This has been manually tested by adding a Markdown `README.md` file to a `doxygen` target in a project, adding `<doxygen:param>USE_MDFILE_AS_MAINPAGE=README.md` to the `requirements` of that `doxygen` target, and verifying that the contents of `README.md` became the `MAINPAGE` of the generated Doxygen documentation.

Note that I did not find tests for other types nor the `doxygen` target, so I did not update any automated tests.  I would gladly add tests for types if anyone has a suggestion on what to do there.  I also would not mind adding a test for the `doxygen` target, but it seems a huge thing to test.
