### PR TITLE
Fix build errors with stdlib=sun-stlport on Linux 

### DIFF
--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -33,11 +33,13 @@ generators.override sun.searched-lib-generator : searched-lib-generator ;
 #
 feature.extend stdlib : sun-stlport ;
 feature.compose <stdlib>sun-stlport
-    : <cxxflags>-library=stlport4 <linkflags>-library=stlport4
+    : <cxxflags>-library=stlport4 <cxxflags>-compat=5
+      <linkflags>-library=stlport4 <linkflags>-compat=5
     ;
 feature.extend stdlib : apache ;
 feature.compose <stdlib>apache
-    : <cxxflags>-library=stdcxx4 <linkflags>-library=stdcxx4
+    : <cxxflags>-library=stdcxx4 <cxxflags>-compat=5
+      <linkflags>-library=stdcxx4 <cxxflags>-compat=5
     ;
 feature.extend stdlib : gnu ;
 feature.compose <stdlib>gnu


### PR DESCRIPTION
For sun-stlport, add -compat=5 to the command line in order to avoid build 
errors on the platforms where it is not the default (like on Linux). Without
this additional option, the compiler exits with an error because
-library=stlport4 only works with the Sun ABI (-compat=5), while the default
might be GNU ABI (-compat=g).

Do the same for the stdcxx library that is also available only in -compat=5
mode. This change is not strictly necessary as the stdcxx library is only
available on Solaris, where the default is -compat=5 anyway. It has been added
as a precaution.