### PR TITLE
Use cygpath in cygwin-to-windows-path

### DIFF
--- a/src/tools/cygwin.jam
+++ b/src/tools/cygwin.jam
@@ -1,74 +1,12 @@
 # Copyright 2004 Vladimir Prus.
 # Copyright 2016 Steven Watanabe
+# Copyright 2017 Peter Dimov
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
 # Provides utility functions for handling cygwin paths
 
-import regex ;
-
-.cygwin-drive-letter-re = ^/cygdrive/([a-z])/(.*) ;
-
-# Like W32_GETREG, except prepend HKEY_CURRENT_USER\SOFTWARE and
-# HKEY_LOCAL_MACHINE\SOFTWARE to the first argument, returning the first result
-# found. Also accounts for the fact that on 64-bit machines, 32-bit software has
-# its own area, under SOFTWARE\Wow6432node.
-#
-local rule software-registry-value ( path : data ? )
-{
-    local result ;
-    for local root in HKEY_CURRENT_USER HKEY_LOCAL_MACHINE
-    {
-        for local x64elt in "" Wow6432node\\ # Account for 64-bit windows
-        {
-            if ! $(result)
-            {
-                result = [ W32_GETREG $(root)\\SOFTWARE\\$(x64elt)$(path) : $(data) ] ;
-            }
-        }
-
-    }
-    return $(result) ;
-}
-
-# :W only works in Cygwin builds of bjam.  This one works on NT builds as well.
-#
 rule cygwin-to-windows-path ( path )
 {
-    path = $(path:R="") ; # strip any trailing slash
-
-    local drive-letter = [ SUBST $(path) $(.cygwin-drive-letter-re) $1:/$2 ] ;
-    if $(drive-letter)
-    {
-        path = $(drive-letter) ;
-    }
-    else if $(path:R=/x) = $(path) # already rooted?
-    {
-        # Look for a cygwin mount that includes each head sequence in $(path).
-        local head = $(path) ;
-        local tail = "" ;
-
-        while $(head)
-        {
-            local root = [ software-registry-value
-                "Cygnus Solutions\\Cygwin\\mounts v2\\"$(head) : native ] ;
-
-            if $(root)
-            {
-                path = $(tail:R=$(root)) ;
-                head = ;
-            }
-            tail = $(tail:R=$(head:D=)) ;
-
-            if $(head) = "/" || [ MATCH  "^([a-zA-Z]:/)$" : $(head) ]
-            {
-                head = ;
-            }
-            else
-            {
-                head = $(head:D) ;
-            }
-        }
-    }
-    return [ regex.replace $(path:R="") / \\ ] ;
+    return [ MATCH "(.*)[\n]+" : [ SHELL "cygpath -w $(path)" ] ] ;
 }


### PR DESCRIPTION
The current logic in `cygwin.cygwin-to-windows-path` doesn't work for me. The path to `ar` that `gcc -print-prog-name=ar` gives is `/usr/lib/gcc/i686-pc-cygwin/6.3.0/../../../../i686-pc-cygwin/bin/ar.exe`, with a Windows equivalent of `C:\cygwin\usr\i686-pc-cygwin\bin\ar.exe`, but the code yields `\usr\i686-pc-cygwin\bin\ar.exe`, which fails.

This patch uses `cygpath -w` instead, which works in my case.