### PR TITLE
Some more `vswhere` improvements

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -162,6 +162,8 @@ set "_known_=1"
 :Skip_VC14
 if NOT "_%BOOST_JAM_TOOLSET%_" == "_vc141_" goto Skip_VC141
 call vswhere_usability_wrapper.cmd
+REM Reset ERRORLEVEL since from now on it's all based on ENV vars
+ver > nul 2> nul
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     if NOT "_%VS150COMNTOOLS%_" == "__" (
         set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -1,20 +1,33 @@
 :: Copyright 2017 - Refael Ackermann
 :: Distributed under MIT style license
 :: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
-:: version: 1.14.0
+:: version: 1.15.4
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
+set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" set "InstallerPath=%ProgramFiles%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" goto :no-vswhere
+:: Manipulate %Path% for easier " handeling
+set Path=%Path%;%InstallerPath%
+where vswhere 2> nul > nul
+if errorlevel 1 goto :no-vswhere
 set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version "[15.0,16.0)"
+vswhere -prerelease > nul
+if "%~1"=="prerelase" set VSWHERE_WITH_PRERELASE=1
+if not errorlevel 1 if "%VSWHERE_WITH_PRERELASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
-set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" exit /B 1
-set Path=%Path%;%VSWHERE%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     endlocal
-    set "VCINSTALLDIR=%%i\VC\"
+    @rem comment out setting VCINSTALLDIR for Boost.build
+    @rem set "VCINSTALLDIR=%%i\VC\"
     set "VS150COMNTOOLS=%%i\Common7\Tools\"
-    exit /B 0)
+    exit /B 0
+)
+
+:no-vswhere
+endlocal
+echo could not find "vswhere"
+exit /B 1


### PR DESCRIPTION
* First commit is just a precaution
* Second commit handles a new feature of `vswhere` https://github.com/Microsoft/vswhere/issues/79 if you want to detect prerelease versions of VS2017 you'll need to call `vswhere_usability_wrapper.cmd prerelease`