### PR TITLE
Python.jam: Postpone the computation of python "major-minor" version …

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -706,14 +706,6 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
     }
     extension-suffix ?= "" ;
 
-    # Normalize and dissect any version number.
-    local major-minor ;
-    if $(version)
-    {
-        major-minor = [ split-version $(version) ] ;
-        version = $(major-minor:J=.) ;
-    }
-
     local cmds-to-try ;
 
     if ! $(cmd-or-prefix) || [ GLOB $(cmd-or-prefix) : * ]
@@ -846,18 +838,28 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
     {
         .numpy = true ;
         .numpy-include = $(result[1]) ;
-	debug-message "NumPy enabled" ;
+        debug-message "NumPy enabled" ;
     }
     else
     {
-	debug-message "NumPy disabled. Reason:" ;
-	debug-message "  $(full-cmd) aborted with " ;
-	debug-message "  $(result[1])" ;
+        debug-message "NumPy disabled. Reason:" ;
+        debug-message "  $(full-cmd) aborted with " ;
+        debug-message "  $(result[1])" ;
     }
 
     #
     # End autoconfiguration sequence.
     #
+    
+    # Normalize and dissect any version number.
+    local major-minor ;
+    if $(version)
+    {
+        major-minor = [ split-version $(version) ] ;
+        version = $(major-minor:J=.) ;
+    }
+    
+    
     local target-requirements = $(condition) ;
 
     # Add the version, if any, to the target requirements.


### PR DESCRIPTION
Following up my post on the ML: this fixes the issue I was having for not being able to build boost.python.

The PR is based on master branch. Included some tabs to space conversion.