### PR TITLE
Fix bash paths in shebangs

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2014 Vladimir Prus
 # Distributed under the Boost Software License, Version 1.0.

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2004, 2005, 2006 Vladimir Prus 
 # Distributed under the Boost Software License, Version 1.0. 

--- a/scripts/roll.sh
+++ b/scripts/roll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2004 Aleksey Gurtovoy
 # Copyright 2006 Rene Rivera

--- a/scripts/to_merge.sh
+++ b/scripts/to_merge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for python in build/*.py; do
     jam="${python%.py}.jam"


### PR DESCRIPTION
"/bin/bash" is a Linuxism.  "/usr/bin/env bash" is portable.