### PR TITLE
Update PGI C++ compiler support

### DIFF
--- a/src/tools/pgi.jam
+++ b/src/tools/pgi.jam
@@ -1,4 +1,5 @@
 #  Copyright Noel Belcourt 2007.
+#  Copyright 2017, NVIDIA CORPORATION.
 #  Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
@@ -36,16 +37,9 @@ rule init ( version ? : command * : options * )
   flags pgi.compile DEFINES $(condition) :
     [ feature.get-values <define> : $(options) ] : unchecked ;
 
-  # IOV_MAX support
-  flags pgi.compile DEFINES $(condition) : __need_IOV_MAX : unchecked ;
-
   # set link flags
   flags pgi.link FINDLIBS-ST : [
     feature.get-values <find-static-library> : $(options) ] : unchecked ;
-
-  # always link lib rt to resolve clock_gettime()
-  flags pgi.link FINDLIBS-SA : rt [
-    feature.get-values <find-shared-library> : $(options) ] : unchecked ;
 
   gcc.init-link-flags pgi gnu $(condition) ;
 }
@@ -56,18 +50,18 @@ generators.register-c-compiler pgi.compile.c++ : CPP : OBJ : <toolset>pgi ;
 generators.register-fortran-compiler pgi.compile.fortran : FORTRAN : OBJ : <toolset>pgi ;
 
 # Declare flags and actions for compilation
-flags pgi.compile OPTIONS : -Kieee ;
-flags pgi.compile OPTIONS <link>shared : -fpic -fPIC ;
+flags pgi.compile OPTIONS <link>shared : -fpic ;
 flags pgi.compile OPTIONS <debug-symbols>on : -gopt ;
-flags pgi.compile OPTIONS <profiling>on : -xprofile=tcov ;
-flags pgi.compile OPTIONS <optimization>speed : -fast -Mx,8,0x10000000 ;
-flags pgi.compile OPTIONS <optimization>space : -xO2 -xspace ;
-# flags pgi.compile OPTIONS <threading>multi : -mt ;
+flags pgi.compile OPTIONS <optimization>off : -O0 ;
+flags pgi.compile OPTIONS <optimization>speed : -fast ;
+flags pgi.compile OPTIONS <optimization>space : -fast ;
 
 flags pgi.compile OPTIONS <warnings>off : -Minform=severe ;
 flags pgi.compile OPTIONS <warnings>on : -Minform=warn ;
+flags pgi.compile OPTIONS <warnings-as-errors>on : -Werror ;
 
-flags pgi.compile.c++ OPTIONS <inlining>off : -INLINE:none ;
+flags pgi.compile.c++ OPTIONS <rtti>off : --no_rtti ;
+flags pgi.compile.c++ OPTIONS <exception-handling>off : --no_exceptions ;
 
 flags pgi.compile OPTIONS <cflags> ;
 flags pgi.compile.c++ OPTIONS <cxxflags> ;
@@ -95,9 +89,8 @@ actions compile.fortran
 flags pgi.link OPTIONS <debug-symbols>on : -gopt ;
 # Strip the binary when no debugging is needed
 flags pgi.link OPTIONS <debug-symbols>off : -s ;
-flags pgi.link OPTIONS <profiling>on : -xprofile=tcov ;
 flags pgi.link OPTIONS <linkflags> ;
-flags pgi.link OPTIONS <link>shared : -fpic -fPIC ;
+flags pgi.link OPTIONS <link>shared : -fpic ;
 flags pgi.link LINKPATH <library-path> ;
 flags pgi.link FINDLIBS-ST <find-static-library> ;
 flags pgi.link FINDLIBS-SA <find-shared-library> ;
@@ -107,24 +100,14 @@ flags pgi.link LINK-RUNTIME <runtime-link>static : static ;
 flags pgi.link LINK-RUNTIME <runtime-link>shared : dynamic ;
 flags pgi.link RPATH <dll-path> ;
 
-# On gcc, there are separate options for dll path at runtime and
-# link time. On Solaris, there's only one: -R, so we have to use
-# it, even though it's bad idea.
-flags pgi.link RPATH <xdll-path> ;
-
 rule link ( targets * : sources * : properties * )
 {
     SPACE on $(targets) = " " ;
 }
 
-# reddish can only link statically and, somehow, the presence of -Bdynamic on the link line 
-# marks the executable as a dynamically linked exec even though no dynamic libraries are supplied.
-# Yod on redstorm refuses to load an executable that is dynamically linked.
-# removing the dynamic link options should get us where we need to be on redstorm.
-# "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -Bdynamic -l$(FINDLIBS-SA) -Bstatic -l$(FINDLIBS-ST) -B$(LINK-RUNTIME)
 actions link bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -Bstatic -l$(FINDLIBS-ST) -Bdynamic -l$(FINDLIBS-SA) -B$(LINK-RUNTIME)
+    "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-ST) -l$(FINDLIBS-SA)
 }
 
 # Slight mods for dlls
@@ -133,11 +116,9 @@ rule link.dll ( targets * : sources * : properties * )
     SPACE on $(targets) = " " ;
 }
 
-# "$(CONFIG_COMMAND)" $(OPTIONS) -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" -h$(<[1]:D=) -G "$(>)" "$(LIBRARIES)" -Bdynamic -l$(FINDLIBS-SA) -Bstatic -l$(FINDLIBS-ST) -B$(LINK-RUNTIME)
-
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" $(OPTIONS) -shared -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" -Wl,-h -Wl,$(<[1]:D=) "$(LIBRARIES)" -Bdynamic -l$(FINDLIBS-SA) -Bstatic -l$(FINDLIBS-ST) -B$(LINK-RUNTIME)
+    "$(CONFIG_COMMAND)" $(OPTIONS) -shared -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST)
 }
 
 actions updated together piecemeal pgi.archive


### PR DESCRIPTION
Update pgi.jam to reflect changes to the PGI C++ compiler over the last five years (which is when regular maintenance of that file stopped happening).