### PR TITLE
Add block comments to jam language.

### DIFF
--- a/doc/bjam.qbk
+++ b/doc/bjam.qbk
@@ -393,7 +393,7 @@ The arguments starting with the "=--option=" forms are passed to the =build.jam=
 must be quoted with double quotes (") to be used as arbitrary tokens, such as
 variable or target names.
 
-Comments start with the [^#] character and extend until the end of line.
+Comments start with the [^#] character and extend until the end of line. And block comments start with [^#*] and extend until the next [^*#].
 
 [endsect]
 

--- a/doc/bjam.qbk
+++ b/doc/bjam.qbk
@@ -393,7 +393,7 @@ The arguments starting with the "=--option=" forms are passed to the =build.jam=
 must be quoted with double quotes (") to be used as arbitrary tokens, such as
 variable or target names.
 
-Comments start with the [^#] character and extend until the end of line. And block comments start with [^#*] and extend until the next [^*#].
+Comments start with the [^#] character and extend until the end of line. And block comments start with [^#|] and extend until the next [^|#].
 
 [endsect]
 

--- a/example/time/jamroot.jam
+++ b/example/time/jamroot.jam
@@ -1,6 +1,8 @@
-# Distributed under the Boost Software License, Version 1.0. (See
-# accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt)
+#*
+Distributed under the Boost Software License, Version 1.0. (See
+accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*#
 
 #[jamroot
 #<< Import the time rule from the testing module.

--- a/example/time/jamroot.jam
+++ b/example/time/jamroot.jam
@@ -1,8 +1,8 @@
-#*
+#|
 Distributed under the Boost Software License, Version 1.0. (See
 accompanying file LICENSE_1_0.txt or copy at
 http://www.boost.org/LICENSE_1_0.txt)
-*#
+|#
 
 #[jamroot
 #<< Import the time rule from the testing module.

--- a/src/engine/scan.c
+++ b/src/engine/scan.c
@@ -283,8 +283,24 @@ int yylex()
             if ( c != '#' )
                 break;
 
-            /* Swallow up comment line. */
-            while ( ( ( c = yychar() ) != EOF ) && ( c != '\n' ) ) ;
+            c = yychar();
+            if ( ( c != EOF ) && c == '*' )
+            {
+                /* Swallow up block comment. */
+                int c0 = yychar();
+                int c1 = yychar();
+                while ( ! ( c0 == '*' && c1 == '#' ) && ( c0 != EOF && c1 != EOF ) )
+                {
+                    c0 = c1;
+                    c1 = yychar();
+                }
+                c = c1;
+            }
+            else
+            {
+                /* Swallow up comment line. */
+                while ( ( c != EOF ) && ( c != '\n' ) ) c = yychar();
+            }
         }
 
         /* c now points to the first character of a token. */

--- a/src/engine/scan.c
+++ b/src/engine/scan.c
@@ -284,12 +284,12 @@ int yylex()
                 break;
 
             c = yychar();
-            if ( ( c != EOF ) && c == '*' )
+            if ( ( c != EOF ) && c == '|' )
             {
                 /* Swallow up block comment. */
                 int c0 = yychar();
                 int c1 = yychar();
-                while ( ! ( c0 == '*' && c1 == '#' ) && ( c0 != EOF && c1 != EOF ) )
+                while ( ! ( c0 == '|' && c1 == '#' ) && ( c0 != EOF && c1 != EOF ) )
                 {
                     c0 = c1;
                     c1 = yychar();


### PR DESCRIPTION
This adds non-nested block comments wrapped with "#*" and "*#". This
should help in cleaning up embedded documentation and generally make
writing jam code easier.