### PR TITLE
PGI C++ compiler support: Set DT_SONAME for shared libraries

### DIFF
--- a/src/tools/pgi.jam
+++ b/src/tools/pgi.jam
@@ -118,7 +118,7 @@ rule link.dll ( targets * : sources * : properties * )
 
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" $(OPTIONS) -shared -L"$(LINKPATH)" -R"$(RPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST)
+    "$(CONFIG_COMMAND)" $(OPTIONS) -shared -L"$(LINKPATH)" -R"$(RPATH)" -soname $(<[-1]:D=) -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST)
 }
 
 actions updated together piecemeal pgi.archive


### PR DESCRIPTION
When creating a shared library, use the -soname option to set the DT_SONAME field to the simple name of the library.  Setting the DT_SONAME field is necessary so that the shared library can be found when it is referenced by another shared library that is then referenced by an executable.