### PR TITLE
Fix for #13154: added -features=zla to the Oracle compiler's command line

### DIFF
--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -33,12 +33,12 @@ generators.override sun.searched-lib-generator : searched-lib-generator ;
 #
 feature.extend stdlib : sun-stlport ;
 feature.compose <stdlib>sun-stlport
-    : <cxxflags>-library=stlport4 <cxxflags>-compat=5
+    : <cxxflags>-library=stlport4 <cxxflags>-compat=5 <cxxflags>-features=zla
       <linkflags>-library=stlport4 <linkflags>-compat=5
     ;
 feature.extend stdlib : apache ;
 feature.compose <stdlib>apache
-    : <cxxflags>-library=stdcxx4 <cxxflags>-compat=5
+    : <cxxflags>-library=stdcxx4 <cxxflags>-compat=5 <cxxflags>-features=zla
       <linkflags>-library=stdcxx4 <cxxflags>-compat=5
     ;
 feature.extend stdlib : gnu ;


### PR DESCRIPTION
Fix for #13154: added -features=zla to the compiler's command line for both libraries that require -compat=5 (stlport and apache). For the GNU library, -compat=g is used through the -std=c++03 option and it includes -features=zla
