### PR TITLE
clang-darwin.jam - allow configuration for <ranlib> & <archiver>

### DIFF
--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -68,6 +68,13 @@ rule init ( version ? :  command * : options * )
 
     gcc.init-link-flags clang darwin $(condition) ;
 
+    # - Ranlib.
+    local ranlib = [ feature.get-values <ranlib> : $(options) ] ;
+    toolset.flags clang-darwin.archive .RANLIB $(condition) : $(ranlib[1]) ;
+
+    # - Archive builder.
+    local archiver = [ feature.get-values <archiver> : $(options) ] ;
+    toolset.flags clang-darwin.archive .AR $(condition) : $(archiver[1]) ;
 }
 
 SPACE = " " ;
@@ -128,6 +135,7 @@ flags clang-darwin ARFLAGS <archiveflags> ;
 # logic in clang-linux, but that's hardly worth the trouble
 # as on Linux, 'ar' is always available.
 .AR = ar ;
+.RANLIB = ranlib -cs ;
 
 rule archive ( targets * : sources * : properties * )
 {
@@ -161,7 +169,7 @@ rule archive ( targets * : sources * : properties * )
 actions piecemeal archive
 {
   "$(.AR)" $(AROPTIONS) rc "$(<)" "$(>)"
-  "ranlib" -cs "$(<)"
+  "$(.RANLIB)" "$(<)"
 }
 
 flags clang-darwin.link USER_OPTIONS <linkflags> ;


### PR DESCRIPTION
When compiling in MacOS with clang, it was not possible to customize the path for **ranlib** and **ar**.

This PR allows to customize the paths by modifying user-config.jam:

```
<archiver>{CUSTOM_TOOLCHAIN_PATH}/arm_16_libc++/bin/arm-linux-androideabi-ar
<ranlib>{CUSTOM_TOOLCHAIN_PATH}/arm_16_libc++/bin/arm-linux-androideabi-ranlib
```

The default behavior was not changed.