### PR TITLE
- clang-linux.jam - allow configuration for <ranlib> & <archiver>

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -60,7 +60,15 @@ rule init ( version ? :  command * : options * ) {
     
   common.handle-options clang-linux : $(condition) : $(command) : $(options) ;
 
-  gcc.init-link-flags clang linux $(condition) ;
+  gcc.init-link-flags clang-linux gnu $(condition) ;
+
+  # - Ranlib.
+  local ranlib = [ feature.get-values <ranlib> : $(options) ] ;
+  toolset.flags clang-linux.archive .RANLIB $(condition) : $(ranlib[1]) ;
+
+  # - Archive builder.
+  local archiver = [ feature.get-values <archiver> : $(options) ] ;
+  toolset.flags clang-linux.archive .AR $(condition) : $(archiver[1]) ;
 }
 
 ###############################################################################
@@ -92,6 +100,10 @@ toolset.flags clang-linux.compile OPTIONS <rtti>off : -fno-rtti ;
 # C and C++ compilation
 
 rule compile.c++ ( targets * : sources * : properties * ) {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
+
   local pth-file = [ on $(<) return $(PCH_FILE) ] ;
 
   if $(pth-file) {
@@ -114,6 +126,10 @@ actions compile.c++.with-pch bind PCH_FILE
 
 rule compile.c ( targets * : sources * : properties * )
 {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
+
   local pth-file = [ on $(<) return $(PCH_FILE) ] ;
 
   if $(pth-file) {
@@ -139,6 +155,9 @@ actions compile.c.with-pch bind PCH_FILE
 # PCH emission
 
 rule compile.c++.pch ( targets * : sources * : properties * ) {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.c++.pch {
@@ -146,6 +165,9 @@ actions compile.c++.pch {
 }
 
 rule compile.c.pch ( targets * : sources * : properties * ) {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.c.pch
@@ -159,6 +181,8 @@ actions compile.c.pch
 SPACE = " " ;
 
 rule link ( targets * : sources * : properties * ) {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
 }
@@ -168,8 +192,27 @@ actions link bind LIBRARIES {
 }
 
 rule link.dll ( targets * : sources * : properties * ) {
+  setup-threading $(targets) : $(sources) : $(properties) ;
+  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
+}
+
+rule setup-threading ( targets * : sources * : properties * )
+{
+
+    local target = [ feature.get-values target-os : $(properties) ] ;
+
+    switch $(target)
+    {
+        case windows :
+            local threading = [ feature.get-values threading : $(properties) ] ;
+            if $(threading) = multi
+                {
+                OPTIONS on $(targets) += -pthread ;
+                }
+        case * : gcc.setup-threading $(targets) : $(sources) : $(properties) ;
+    }
 }
 
 # Differ from 'link' above only by -shared.

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -60,7 +60,7 @@ rule init ( version ? :  command * : options * ) {
     
   common.handle-options clang-linux : $(condition) : $(command) : $(options) ;
 
-  gcc.init-link-flags clang-linux gnu $(condition) ;
+  gcc.init-link-flags clang-linux $(condition) ;
 
   # - Ranlib.
   local ranlib = [ feature.get-values <ranlib> : $(options) ] ;
@@ -100,10 +100,6 @@ toolset.flags clang-linux.compile OPTIONS <rtti>off : -fno-rtti ;
 # C and C++ compilation
 
 rule compile.c++ ( targets * : sources * : properties * ) {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
-
   local pth-file = [ on $(<) return $(PCH_FILE) ] ;
 
   if $(pth-file) {
@@ -126,10 +122,6 @@ actions compile.c++.with-pch bind PCH_FILE
 
 rule compile.c ( targets * : sources * : properties * )
 {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
-
   local pth-file = [ on $(<) return $(PCH_FILE) ] ;
 
   if $(pth-file) {
@@ -155,9 +147,6 @@ actions compile.c.with-pch bind PCH_FILE
 # PCH emission
 
 rule compile.c++.pch ( targets * : sources * : properties * ) {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.c++.pch {
@@ -165,9 +154,6 @@ actions compile.c++.pch {
 }
 
 rule compile.c.pch ( targets * : sources * : properties * ) {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-fpic $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.c.pch
@@ -181,8 +167,6 @@ actions compile.c.pch
 SPACE = " " ;
 
 rule link ( targets * : sources * : properties * ) {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
 }
@@ -192,27 +176,8 @@ actions link bind LIBRARIES {
 }
 
 rule link.dll ( targets * : sources * : properties * ) {
-  setup-threading $(targets) : $(sources) : $(properties) ;
-  gcc.setup-address-model $(targets) : $(sources) : $(properties) ;
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
-}
-
-rule setup-threading ( targets * : sources * : properties * )
-{
-
-    local target = [ feature.get-values target-os : $(properties) ] ;
-
-    switch $(target)
-    {
-        case windows :
-            local threading = [ feature.get-values threading : $(properties) ] ;
-            if $(threading) = multi
-                {
-                OPTIONS on $(targets) += -pthread ;
-                }
-        case * : gcc.setup-threading $(targets) : $(sources) : $(properties) ;
-    }
 }
 
 # Differ from 'link' above only by -shared.

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -60,7 +60,7 @@ rule init ( version ? :  command * : options * ) {
     
   common.handle-options clang-linux : $(condition) : $(command) : $(options) ;
 
-  gcc.init-link-flags clang-linux $(condition) ;
+  gcc.init-link-flags clang linux $(condition) ;
 
   # - Ranlib.
   local ranlib = [ feature.get-values <ranlib> : $(options) ] ;


### PR DESCRIPTION
basically, the same as #232 , but for clang-linux.jam. needed for Clang on Windows.