### PR TITLE
- also check for uppercased variable names PROGRAMFILES(X86) and PROG…

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1260,7 +1260,15 @@ local rule default-path ( version )
             local root = [ os.environ "ProgramFiles(x86)" ] ;
             if ( ! $(root) )
             {
+                root = [ os.environ "PROGRAMFILES(X86)" ] ;
+            }
+            if ( ! $(root) )
+            {
                 root = [ os.environ "ProgramFiles" ] ;
+            }
+            if ( ! $(root) )
+            {
+                root = [ os.environ "PROGRAMFILES" ] ;
             }
             local vswhere = "$(root)\\Microsoft Visual Studio\\Installer\\vswhere.exe" ;
             if ( [ path.exists $(vswhere) ] )


### PR DESCRIPTION
…RAMFILES.

This increases robustness and interoperability with third-party tools.
Some tools only provide environments with forcibly upper-cased
environment variable names (notably, Qt Creator). Running b2 under
these tools will otherwise fail.

Perhaps a better approach would be to support case-insensitive
environment variables in b2, but that isn't trivial to do.