### PR TITLE
Fix compiler warnings about deprecated language features

### DIFF
--- a/src/engine/execcmd.c
+++ b/src/engine/execcmd.c
@@ -10,6 +10,7 @@
 
 #include "jam.h"
 #include "execcmd.h"
+#include "output.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/src/engine/execnt.c
+++ b/src/engine/execnt.c
@@ -569,7 +569,7 @@ static int raw_maxline()
 
 static int maxline()
 {
-    static result;
+    static int result;
     if ( !result ) result = raw_maxline();
     return result;
 }

--- a/src/engine/filent.c
+++ b/src/engine/filent.c
@@ -50,6 +50,8 @@
 #include <io.h>
 
 
+int file_collect_archive_content_( file_archive_info_t * const archive );
+
 /*
  * file_collect_dir_content_() - collects directory content information
  */

--- a/src/engine/filesys.h
+++ b/src/engine/filesys.h
@@ -96,6 +96,8 @@ file_info_t * filelist_item( FILELISTITER it );
 file_info_t * filelist_front(  FILELIST * list );
 file_info_t * filelist_back(  FILELIST * list );
 
+int filelist_empty( FILELIST * list );
+
 #define FL0 ((FILELIST *)0)
 
 

--- a/src/engine/jam.c
+++ b/src/engine/jam.c
@@ -121,6 +121,7 @@
 #include "strings.h"
 #include "timestamp.h"
 #include "variable.h"
+#include "execcmd.h"
 
 /* Macintosh is "special" */
 #ifdef OS_MAC

--- a/src/engine/make.c
+++ b/src/engine/make.c
@@ -44,6 +44,8 @@
 #include "search.h"
 #include "timestamp.h"
 #include "variable.h"
+#include "execcmd.h"
+#include "output.h"
 
 #include <assert.h>
 

--- a/src/engine/modules/path.c
+++ b/src/engine/modules/path.c
@@ -8,7 +8,7 @@
 #include "../frames.h"
 #include "../lists.h"
 #include "../native.h"
-#include "../timestamp.h"
+#include "../filesys.h"
 
 
 LIST * path_exists( FRAME * frame, int flags )


### PR DESCRIPTION
Bootstrap log contains warnings about using of old-style C features:

- implicit function declaration;
- implicit `int.`

By adding some includes, declarations of existing functions, and by explicitly specifying the `int` type we can get clean bootstrap log. 

There is also an unnecessary include directive in [src/engine/modules/path.c](https://github.com/boostorg/build/compare/develop...karzhenkov:fix-compiler-warnings?expand=1#diff-d97793838c95293d5f2ece81a49d63de)