### PR TITLE
Use python-config to get python paths

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -503,6 +503,22 @@ local rule probe ( python-cmd )
 }
 
 
+# Use python-config command to get default paths
+#
+local rule compute-python-config-paths ( version ? : exec-prefix ? )
+{
+    local cfg-cmd = $(exec-prefix)/bin/python$(version)-config ;
+
+    local includes-cmd =
+        $(cfg-cmd)" --includes | sed -n 's/^-I\(.*\) .*/\1/p' | tr -d '\\n'" ;
+    includes ?= [ shell-cmd $(includes-cmd) ] ;
+
+    local libraries-cmd =
+	      $(cfg-cmd)" --ldflags | sed -n 's/^-L\(.*\) .*/\1/p' | tr -d '\\n'" ;
+    libraries ?= [ shell-cmd $(libraries-cmd) ] ;
+}
+
+
 # Make sure the "libraries" and "includes" variables (in an enclosing scope)
 # have a value based on the information given.
 #
@@ -544,6 +560,9 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
     }
     else
     {
+        # try python-config first
+        compute-python-config-paths $(version) : $(exec-prefix) ;
+
         includes ?= $(prefix)/include/python$(version) ;
 
         local lib = $(exec-prefix)/lib ;


### PR DESCRIPTION
Sometimes python appends additional letters after a version number in its paths (for example `/usr/inlude/python3.6m`). This caused an error when building `boost_python` with default configuration, as described on [https://svn.boost.org/trac10/ticket/11120](https://svn.boost.org/trac10/ticket/11120). The patch enables `python-config` command to determine library and include paths.