### PR TITLE
Prevent vcvarsall.bat from changing current directory

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -172,7 +172,9 @@ if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
 if "_%BOOST_JAM_ARCH%_" == "__" set BOOST_JAM_ARCH=x86
 set BOOST_JAM_ARGS=%BOOST_JAM_ARGS% %BOOST_JAM_ARCH%
 
+pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %BOOST_JAM_ARGS%
+popd
 set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
 set "BOOST_JAM_OPT_JAM=/Febootstrap\jam0"
 set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -172,7 +172,7 @@ if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
 if "_%BOOST_JAM_ARCH%_" == "__" set BOOST_JAM_ARCH=x86
 set BOOST_JAM_ARGS=%BOOST_JAM_ARGS% %BOOST_JAM_ARCH%
 
-pushd %CD%
+pushd .
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %BOOST_JAM_ARGS%
 popd
 set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"


### PR DESCRIPTION
Building with VS2017 15.3.5 produces following error:

c1: fatal error C1083: Cannot open source file: 'yyacc.c': No such file or directory

This happens because vsdevcmd_end.bat changes current directory to %USERPROFILE%\Source if it exists.