### PR TITLE
Fix subfeature name

### DIFF
--- a/src/tools/features/cxxstd-feature.jam
+++ b/src/tools/features/cxxstd-feature.jam
@@ -30,5 +30,5 @@ feature.feature cxxstd
 # ANSI C++ Standard conformance.
 
 feature.subfeature cxxstd : dialect
-    : gnu ms
+    : gnu++ ms
     : optional composite propagated ;


### PR DESCRIPTION
When using `cxxstd-dialect=` gcc.jam simply appends the version number to the dialect name, but -std=gnu03 isn't a valid option for C++ builds (only Objective C), we want to generate `-std=gnu++03` etc.  Hence the change of subfeature name.  As far as I can tell no one is actually using this (and if they are it isn't doing what they want), so the change should be safe.