### PR TITLE
Add test/Jamfile

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,0 +1,6 @@
+import testing ;
+import type ;
+
+type.register PY : py : EXE ;
+
+run test_all.py : : : <testing.launcher>python ;


### PR DESCRIPTION
This adds a `Jamfile` in `test` that just calls `python test_all.py`, so that the `b2 submodule-dir/test` command invoked by the superproject Travis runs the tests.