### PR TITLE
Enable detection of python's build flags for include dir

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -545,6 +545,12 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
     else
     {
         includes ?= $(prefix)/include/python$(version) ;
+        if $(sys.abiflags)
+        {
+            # Calling "sys.abiflags" does not throw an exception, which 
+            # indicates this is not a build from source distro.
+            includes ?= $(includes)$(sys.abiflags) ;
+        }
 
         local lib = $(exec-prefix)/lib ;
         libraries ?= $(lib)/python$(version)/config $(lib) ;
@@ -746,7 +752,7 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
     {
         # Values to be extracted from python's sys module. These will be set by
         # the probe rule, above, using Jam's dynamic scoping.
-        local sys-elements = version platform prefix exec_prefix executable ;
+        local sys-elements = version platform prefix exec_prefix executable abiflags ;
         local sys.$(sys-elements) ;
 
         # Compute the string Python's sys.platform needs to match. If not

--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -548,7 +548,8 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
         if $(sys.abiflags)
         {
             # Calling "sys.abiflags" does not throw an exception, which 
-            # indicates this is not a build from source distro.
+            # indicates this is neither a Python 2 build, nor a build from
+            # source distro.
             includes ?= $(includes)$(sys.abiflags) ;
         }
 


### PR DESCRIPTION
Many Linux distributions would put python3's include header into directories like `/usr/include/python3.6m` instead of  paths like `/usr/include/python3.6` where `m` is python's abi build flag. Previously the automatic guess for python's header include directory did not consider such situation, thus the commit. The implementation itself is inspired by Python's distutil module(or more precisely, `distuils.sysconfig.get_python_inc` function).