### PR TITLE
Find lzma and zstd for VisualC++ builds.

### DIFF
--- a/src/tools/lzma.jam
+++ b/src/tools/lzma.jam
@@ -24,7 +24,8 @@ import property ;
 import property-set ;
 
 header = lzma.h ;
-names = lzma ;
+# liblzma only needed for VisualC++ builds
+names = lzma liblzma ;
 
 library-id = 0 ;
 

--- a/src/tools/zstd.jam
+++ b/src/tools/zstd.jam
@@ -24,7 +24,9 @@ import property ;
 import property-set ;
 
 header = zstd.h ;
-names = zstd ;
+# libzstd only needed for VisualC++ builds
+# *_static variants for prebuilt Windows static libraries
+names = zstd zstd_static libzstd libzstd_static ;
 
 library-id = 0 ;
 


### PR DESCRIPTION
gcc builds add the lib prefix on their own,
for VisualC++ we need to do it manually.