### PR TITLE
Avoid 100% CPU utilization if no timeout is set

### DIFF
--- a/src/engine/execunix.c
+++ b/src/engine/execunix.c
@@ -499,11 +499,17 @@ void exec_wait()
         {
             /* disable child termination signals while in select */
             int ret;
+            int timeout;
             sigset_t sigmask;
             sigemptyset(&sigmask);
             sigaddset(&sigmask, SIGCHLD);
             sigprocmask(SIG_BLOCK, &sigmask, NULL);
-            while ( ( ret = poll( wait_fds, WAIT_FDS_SIZE, select_timeout * 1000 ) ) == -1 )
+
+            /* If no timeout is specified, pass -1 (which means no timeout,
+             * wait indefinitely) to poll, to prevent busy-looping.
+             */
+            timeout = select_timeout? select_timeout * 1000 : -1;
+            while ( ( ret = poll( wait_fds, WAIT_FDS_SIZE, timeout ) ) == -1 )
                 if ( errno != EINTR )
                     break;
             /* restore original signal mask by unblocking sigchld */


### PR DESCRIPTION
While building boost, I noticed that jam0 and bjam used 100% of a CPU.
Strace showed that they were calling poll with a zero timeout in a loop.
This is because:
- the logic in exec_wait() initializes select_timeout to globs.timeout
- globs.timeout is zero when no action timeout is specified
- poll interprets a zero timeout as "return immediately" rather than
  "wait indefinitely".

Fix this by using a poll timeout of one minute when globs.timeout is
zero. Note that the value of one minute is arbitrary: Other values
should work just as well.