### PR TITLE
Make `toolset=clang-win` initialize the clang-win toolset

### DIFF
--- a/src/tools/clang.jam
+++ b/src/tools/clang.jam
@@ -17,7 +17,12 @@ feature.subfeature toolset clang : platform : : propagated link-incompatible ;
 
 rule init ( * : * )
 {
-    if [ os.name ] = MACOSX
+    if $(1) = win
+    {
+        toolset.using clang-win :
+          $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) ;
+    }
+    else if [ os.name ] = MACOSX
     {
         toolset.using clang-darwin : 
           $(1) : $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) ;


### PR DESCRIPTION
This is more an RFC although it can be applied as-is; it makes `toolset=clang-win` initialize the `clang-win` toolset instead of `clang-linux` with a version `win` which is rarely what one wants.

It still doesn't work because then `clang-win` complains of missing `<compatibility>`, and I see no way of supplying that from the command line. Ideally, we should strive for `toolset=clang-win` working out of the box, but I don't know how feasible this is.