### PR TITLE
Enable VS 2017 Preview to be used

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -98,7 +98,7 @@ if errorlevel 1 (
     set "VS_ProgramFiles=%ProgramFiles%"
 )
 
-call guess_toolset.bat
+call guess_toolset.bat %isPrerelease%
 if errorlevel 1 (
     call :Error_Print "Could not find a suitable toolset."
     goto :eof)
@@ -114,6 +114,11 @@ goto :eof
 :Start
 set BOOST_JAM_TOOLSET=
 set BOOST_JAM_ARGS=
+
+if "%~1"=="prerelease" (
+  set isPrerelease=%~1
+  shift
+)
 
 REM If no arguments guess the toolset;
 REM or if first argument is an option guess the toolset;
@@ -159,7 +164,7 @@ if errorlevel 1 (
     goto Setup_Args
 )
 :Config_Toolset
-call config_toolset.bat 
+call config_toolset.bat %isPrerelease%
 if "_%_known_%_" == "__" (
     call :Error_Print "Unknown toolset: %BOOST_JAM_TOOLSET%"
 )
@@ -167,6 +172,7 @@ if errorlevel 1 goto Finish
 
 echo ###
 echo ### Using '%BOOST_JAM_TOOLSET%' toolset.
+echo ### Using '%BOOST_JAM_TOOLSET_ROOT%' toolset root.
 echo ###
 
 set YYACC_SOURCES=yyacc.c

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -161,7 +161,7 @@ set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
 set "_known_=1"
 :Skip_VC14
 if NOT "_%BOOST_JAM_TOOLSET%_" == "_vc141_" goto Skip_VC141
-call vswhere_usability_wrapper.cmd
+call vswhere_usability_wrapper.cmd %1
 REM Reset ERRORLEVEL since from now on it's all based on ENV vars
 ver > nul 2> nul
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (

--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -28,7 +28,7 @@ goto :eof
 :Guess
 REM Check the variable first. This can be set manually by the user (by running the tools commmand prompt).
 call :Clear_Error
-call vswhere_usability_wrapper.cmd
+call vswhere_usability_wrapper.cmd %1
 if NOT "_%VS150COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET=vc141"
     set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -16,8 +16,8 @@ set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version "[15.0,16.0)"
 vswhere -prerelease > nul
-if "%~1"=="prerelase" set VSWHERE_WITH_PRERELASE=1
-if not errorlevel 1 if "%VSWHERE_WITH_PRERELASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
+if "%~1"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
+if not errorlevel 1 if "%VSWHERE_WITH_PRERELEASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     endlocal


### PR DESCRIPTION
# This feature enables VS 2017 Preview to be used.

## Changes

Pass ```bootstrap.bat prerelease``` parameter to ```config_toolset.bat```, ```guess_toolset.bat``` and ```vswhere_usability_wrapper.cmd``` scripts.

**Fixed typos**
- VSWHERE_WITH_PRERELASE -> **VSWHERE_WITH_PRERELEASE**
- prerelase -> **prerelease**