### PR TITLE
Add visibility feature

### DIFF
--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -522,6 +522,26 @@ in contexts where conditional properties are not allowed
 tell Boost.Build that the feature is actually used.
 ** Generators and targets that manipulate property-sets directly. Solution: set <relevant> manually.
 
+[[bbv2.builtin.features.visibility]]`visibility`::
+*Allowed values:* `global`, `protected`, `hidden`.
++
+This feature is used to specify the default symbol visibility in compiled
+binaries. Not all values are supported on all platforms and on some
+platforms (for example, Windows) symbol visibility is not supported at all.
++
+The supported values have the following meaning:
++
+* `global` - a.k.a. "default" in gcc documentation. Global symbols are considered
+  public, they are exported from shared libraries and can be redefined by another
+  shared library or executable. This is the default value.
+* `protected` - a.k.a. "symbolic". Protected symbols are exported from shared
+  libraries but cannot be redefined by another shared library or executable.
+  This mode is not supported on some platforms, for example OS X.
+* `hidden` - Hidden symbols are not exported from shared libraries and cannot
+  be redefined by a different shared library or executable loaded in a process.
+  In this mode, public symbols have to be explicitly marked in the source code
+  to be exported from shared libraries. This is the recommended mode.
+
 [[bbv2.reference.tools]]
 == Builtin tools
 

--- a/src/tools/features/visibility-feature.jam
+++ b/src/tools/features/visibility-feature.jam
@@ -1,0 +1,10 @@
+# Copyright 2018 Andrey Semashev
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import feature ;
+
+feature.feature visibility
+    : global protected hidden
+    : propagated optional ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -718,6 +718,12 @@ toolset.flags gcc.compile OPTIONS <warnings-as-errors>on : -Werror ;
 toolset.flags gcc.compile OPTIONS <debug-symbols>on : -g ;
 toolset.flags gcc.compile OPTIONS <profiling>on : -pg ;
 
+toolset.flags gcc.compile OPTIONS <visibility>hidden : -fvisibility=hidden ;
+toolset.flags gcc.compile.c++ OPTIONS <visibility>hidden : -fvisibility-inlines-hidden ;
+toolset.flags gcc.compile OPTIONS <visibility>protected : -fvisibility=protected ;
+toolset.flags gcc.compile OPTIONS <visibility>protected/<target-os>darwin : ;
+toolset.flags gcc.compile OPTIONS <visibility>global : -fvisibility=default ;
+
 toolset.flags gcc.compile.c++ OPTIONS <rtti>off : -fno-rtti ;
 toolset.flags gcc.compile.c++ OPTIONS <exception-handling>off : -fno-exceptions ;
 
@@ -854,6 +860,12 @@ toolset.flags gcc.link LINKPATH <library-path> ;
 toolset.flags gcc.link FINDLIBS-ST <find-static-library> ;
 toolset.flags gcc.link FINDLIBS-SA <find-shared-library> ;
 toolset.flags gcc.link LIBRARIES <library-file> ;
+
+# Specify compile flags for linker as well as they may be needed for LTO
+toolset.flags gcc.link OPTIONS <visibility>hidden : -fvisibility=hidden -fvisibility-inlines-hidden ;
+toolset.flags gcc.link OPTIONS <visibility>protected : -fvisibility=protected ;
+toolset.flags gcc.link OPTIONS <visibility>protected/<target-os>darwin : ;
+toolset.flags gcc.link OPTIONS <visibility>global : -fvisibility=default ;
 
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>windows : "-Wl,--out-implib," ;
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib," ;

--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -65,6 +65,11 @@ toolset.flags qcc.compile OPTIONS <warnings-as-errors>on : -Wc,-Werror ;
 
 toolset.flags qcc.compile OPTIONS <profiling>on : -p ;
 
+toolset.flags qcc.compile OPTIONS <visibility>hidden : -fvisibility=hidden ;
+toolset.flags qcc.compile.c++ OPTIONS <visibility>hidden : -fvisibility-inlines-hidden ;
+toolset.flags qcc.compile OPTIONS <visibility>protected : -fvisibility=protected ;
+toolset.flags qcc.compile OPTIONS <visibility>global : -fvisibility=default ;
+
 toolset.flags qcc.compile OPTIONS <cflags> ;
 toolset.flags qcc.compile.c++ OPTIONS <cxxflags> ;
 toolset.flags qcc.compile DEFINES <define> ;

--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -135,6 +135,10 @@ flags sun.compile OPTIONS <warnings>on : -erroff=%none ;
 flags sun.compile OPTIONS <warnings>all  : -erroff=%none ;
 flags sun.compile OPTIONS <warnings-as-errors>on : -errwarn ;
 
+flags sun.compile OPTIONS <visibility>hidden : -xldscope=hidden ;
+flags sun.compile OPTIONS <visibility>protected : -xldscope=symbolic ;
+flags sun.compile OPTIONS <visibility>global : -xldscope=global ;
+
 flags sun.compile.c++ OPTIONS <inlining>off : +d ;
 
 # The -m32 and -m64 options are supported starting

--- a/src/tools/xlcpp.jam
+++ b/src/tools/xlcpp.jam
@@ -95,6 +95,10 @@ else
     # Linux PPC
     flags xlcpp.compile CFLAGS <link>shared : -qpic=large ;
     flags xlcpp FINDLIBS : rt ;
+
+    flags xlcpp.compile OPTIONS <visibility>hidden : -qvisibility=hidden ;
+    flags xlcpp.compile OPTIONS <visibility>protected : -qvisibility=protected ;
+    flags xlcpp.compile OPTIONS <visibility>global : -qvisibility=default ;
 }
 
 # Profiling


### PR DESCRIPTION
The new visibility feature can be used to specify default symbol visibility
on compilers and platforms that support it. The default visibility is
hidden, unlike most compilers' defaults. This is intentional so that all
Boost libraries are compiled with hidden visibility by default. Other modes
are: protected and global (the latter is called "default" in gcc documentation).

I've only tested it on Linux, with gcc and clang.

The discussion that led to this PR is here:

http://boost.2283326.n4.nabble.com/all-Request-for-out-of-the-box-visibility-support-tt4704134.html
