### PR TITLE
boost/build: fix ch declaration in debugger.c

### DIFF
--- a/src/engine/debugger.c
+++ b/src/engine/debugger.c
@@ -978,7 +978,7 @@ static void debug_parent_on_end_stepping( void )
 /* Waits for events from the child. */
 static void debug_parent_wait( int print_message )
 {
-    char ch = fgetc( command_child );
+    int ch = fgetc( command_child );
     if ( ch == DEBUG_MSG_BREAKPOINT )
     {
         debug_parent_on_breakpoint();


### PR DESCRIPTION
fix declaration of ch variable in debug_parent_wait() to be an int rather than a char. fgetc does return an int and if return variable is declared to be a char truncation occurs that results in later comparisons of ch to EOF to fail (0xff compare to 0xffffffff) on ppc64le.