### PR TITLE
Make visibility feature not propagated

### DIFF
--- a/src/tools/features/visibility-feature.jam
+++ b/src/tools/features/visibility-feature.jam
@@ -7,4 +7,4 @@ import feature ;
 
 feature.feature visibility
     : global protected hidden
-    : propagated optional ;
+    : optional ;


### PR DESCRIPTION
This allows to enable hidden visibility on a library without affecting its dependencies, which may not (yet) support hidden visibility by default.