### PR TITLE
Add VxWorks process extension.

### DIFF
--- a/src/tools/types/exe.jam
+++ b/src/tools/types/exe.jam
@@ -7,3 +7,4 @@ import type ;
 type.register EXE ;
 type.set-generated-target-suffix EXE : <target-os>windows : "exe" ;
 type.set-generated-target-suffix EXE : <target-os>cygwin : "exe" ;
+type.set-generated-target-suffix EXE : <target-os>vxworks : "vxe" ;


### PR DESCRIPTION
We use "vxe" extension for VxWorks processes by convention, no tool requires it, its just an easy way to identify the cross built executable.