### PR TITLE
Add local-visibility feature, mark visibility as a propagated feature

### DIFF
--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -533,7 +533,7 @@ The supported values have the following meaning:
 +
 * `global` - a.k.a. "default" in gcc documentation. Global symbols are considered
   public, they are exported from shared libraries and can be redefined by another
-  shared library or executable. This is the default value.
+  shared library or executable.
 * `protected` - a.k.a. "symbolic". Protected symbols are exported from shared
   libraries but cannot be redefined by another shared library or executable.
   This mode is not supported on some platforms, for example OS X.
@@ -541,6 +541,25 @@ The supported values have the following meaning:
   be redefined by a different shared library or executable loaded in a process.
   In this mode, public symbols have to be explicitly marked in the source code
   to be exported from shared libraries. This is the recommended mode.
++
+By default compiler default visibility mode is used (no compiler flags are added).
++
+NOTE: In Boost superproject Jamroot file this property is set to the default
+value of `hidden`. This means that Boost libraries are built with hidden
+visibility by default, unless the user overrides it with a different `visibility`
+or a library sets a different `local-visibility` (see below).
+
+[[bbv2.builtin.features.local-visibility]]`local-visibility`::
+*Allowed values:* `global`, `protected`, `hidden`.
++
+This feature has the same effect as the `visibility` feature but is intended
+to be used by targets that require a particular symbol visibility. Unlike
+the `visibility` feature, `local-visibility` is not inherited by the target
+dependencies and only affects the target to which it is applied.
++
+The `local-visibility` feature supports the same values with the same meaning
+as the `visibility` feature. By default, if `local-visibility` is not specified
+for a target, the value of the `visibility` feature is used.
 
 [[bbv2.reference.tools]]
 == Builtin tools

--- a/src/tools/features/local-visibility-feature.jam
+++ b/src/tools/features/local-visibility-feature.jam
@@ -1,0 +1,10 @@
+# Copyright 2018 Andrey Semashev
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import feature ;
+
+feature.feature local-visibility
+    : global protected hidden
+    : optional ;

--- a/src/tools/features/visibility-feature.jam
+++ b/src/tools/features/visibility-feature.jam
@@ -7,4 +7,8 @@ import feature ;
 
 feature.feature visibility
     : global protected hidden
-    : optional ;
+    : optional composite propagated ;
+
+feature.compose <visibility>global : <local-visibility>global ;
+feature.compose <visibility>protected : <local-visibility>protected ;
+feature.compose <visibility>hidden : <local-visibility>hidden ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -718,11 +718,11 @@ toolset.flags gcc.compile OPTIONS <warnings-as-errors>on : -Werror ;
 toolset.flags gcc.compile OPTIONS <debug-symbols>on : -g ;
 toolset.flags gcc.compile OPTIONS <profiling>on : -pg ;
 
-toolset.flags gcc.compile OPTIONS <visibility>hidden : -fvisibility=hidden ;
-toolset.flags gcc.compile.c++ OPTIONS <visibility>hidden : -fvisibility-inlines-hidden ;
-toolset.flags gcc.compile OPTIONS <visibility>protected : -fvisibility=protected ;
-toolset.flags gcc.compile OPTIONS <visibility>protected/<target-os>darwin : ;
-toolset.flags gcc.compile OPTIONS <visibility>global : -fvisibility=default ;
+toolset.flags gcc.compile OPTIONS <local-visibility>hidden : -fvisibility=hidden ;
+toolset.flags gcc.compile.c++ OPTIONS <local-visibility>hidden : -fvisibility-inlines-hidden ;
+toolset.flags gcc.compile OPTIONS <local-visibility>protected : -fvisibility=protected ;
+toolset.flags gcc.compile OPTIONS <local-visibility>protected/<target-os>darwin : ;
+toolset.flags gcc.compile OPTIONS <local-visibility>global : -fvisibility=default ;
 
 toolset.flags gcc.compile.c++ OPTIONS <rtti>off : -fno-rtti ;
 toolset.flags gcc.compile.c++ OPTIONS <exception-handling>off : -fno-exceptions ;
@@ -862,10 +862,10 @@ toolset.flags gcc.link FINDLIBS-SA <find-shared-library> ;
 toolset.flags gcc.link LIBRARIES <library-file> ;
 
 # Specify compile flags for linker as well as they may be needed for LTO
-toolset.flags gcc.link OPTIONS <visibility>hidden : -fvisibility=hidden -fvisibility-inlines-hidden ;
-toolset.flags gcc.link OPTIONS <visibility>protected : -fvisibility=protected ;
-toolset.flags gcc.link OPTIONS <visibility>protected/<target-os>darwin : ;
-toolset.flags gcc.link OPTIONS <visibility>global : -fvisibility=default ;
+toolset.flags gcc.link OPTIONS <local-visibility>hidden : -fvisibility=hidden -fvisibility-inlines-hidden ;
+toolset.flags gcc.link OPTIONS <local-visibility>protected : -fvisibility=protected ;
+toolset.flags gcc.link OPTIONS <local-visibility>protected/<target-os>darwin : ;
+toolset.flags gcc.link OPTIONS <local-visibility>global : -fvisibility=default ;
 
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>windows : "-Wl,--out-implib," ;
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib," ;

--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -65,10 +65,10 @@ toolset.flags qcc.compile OPTIONS <warnings-as-errors>on : -Wc,-Werror ;
 
 toolset.flags qcc.compile OPTIONS <profiling>on : -p ;
 
-toolset.flags qcc.compile OPTIONS <visibility>hidden : -fvisibility=hidden ;
-toolset.flags qcc.compile.c++ OPTIONS <visibility>hidden : -fvisibility-inlines-hidden ;
-toolset.flags qcc.compile OPTIONS <visibility>protected : -fvisibility=protected ;
-toolset.flags qcc.compile OPTIONS <visibility>global : -fvisibility=default ;
+toolset.flags qcc.compile OPTIONS <local-visibility>hidden : -fvisibility=hidden ;
+toolset.flags qcc.compile.c++ OPTIONS <local-visibility>hidden : -fvisibility-inlines-hidden ;
+toolset.flags qcc.compile OPTIONS <local-visibility>protected : -fvisibility=protected ;
+toolset.flags qcc.compile OPTIONS <local-visibility>global : -fvisibility=default ;
 
 toolset.flags qcc.compile OPTIONS <cflags> ;
 toolset.flags qcc.compile.c++ OPTIONS <cxxflags> ;

--- a/src/tools/sun.jam
+++ b/src/tools/sun.jam
@@ -135,9 +135,9 @@ flags sun.compile OPTIONS <warnings>on : -erroff=%none ;
 flags sun.compile OPTIONS <warnings>all  : -erroff=%none ;
 flags sun.compile OPTIONS <warnings-as-errors>on : -errwarn ;
 
-flags sun.compile OPTIONS <visibility>hidden : -xldscope=hidden ;
-flags sun.compile OPTIONS <visibility>protected : -xldscope=symbolic ;
-flags sun.compile OPTIONS <visibility>global : -xldscope=global ;
+flags sun.compile OPTIONS <local-visibility>hidden : -xldscope=hidden ;
+flags sun.compile OPTIONS <local-visibility>protected : -xldscope=symbolic ;
+flags sun.compile OPTIONS <local-visibility>global : -xldscope=global ;
 
 flags sun.compile.c++ OPTIONS <inlining>off : +d ;
 

--- a/src/tools/xlcpp.jam
+++ b/src/tools/xlcpp.jam
@@ -96,9 +96,9 @@ else
     flags xlcpp.compile CFLAGS <link>shared : -qpic=large ;
     flags xlcpp FINDLIBS : rt ;
 
-    flags xlcpp.compile OPTIONS <visibility>hidden : -qvisibility=hidden ;
-    flags xlcpp.compile OPTIONS <visibility>protected : -qvisibility=protected ;
-    flags xlcpp.compile OPTIONS <visibility>global : -qvisibility=default ;
+    flags xlcpp.compile OPTIONS <local-visibility>hidden : -qvisibility=hidden ;
+    flags xlcpp.compile OPTIONS <local-visibility>protected : -qvisibility=protected ;
+    flags xlcpp.compile OPTIONS <local-visibility>global : -qvisibility=default ;
 }
 
 # Profiling


### PR DESCRIPTION
This is a result of the discussion in https://github.com/boostorg/build/pull/333.

local-visibility is intended to be used by libraries or targets that require
a particular visibility mode. It is not propagated to dependencies. It is
equivalent to the previous visibility feature.

The new visibility feature is a composite propagated feature, so it can be
specified by users and higher level targets as a requirement. This feature is
translated to local-visibility.