### PR TITLE
Use correct sizeof in malloc call

### DIFF
--- a/src/engine/hash.c
+++ b/src/engine/hash.c
@@ -248,7 +248,7 @@ static void hashrehash( struct hash * hp )
         BJAM_FREE( (char *)hp->tab.base );
 
     hp->tab.nel = hp->items.nel * hp->bloat;
-    hp->tab.base = (ITEM * *)BJAM_MALLOC( hp->tab.nel * sizeof( ITEM * * ) );
+    hp->tab.base = (ITEM * *)BJAM_MALLOC( hp->tab.nel * sizeof( ITEM * ) );
 
     memset( (char *)hp->tab.base, '\0', hp->tab.nel * sizeof( ITEM * ) );
 


### PR DESCRIPTION
This is allocating space for `nel` objects of type `ITEM*` so it should use `sizeof(ITEM*)` not `sizeof(ITEM**)`.

In practice the values are the same, but using the correct type is better anyway, and now matches the same calculation in the `memset` call in the following statement.