### PR TITLE
Fix memory leak

### DIFF
--- a/src/engine/debugger.c
+++ b/src/engine/debugger.c
@@ -860,10 +860,11 @@ static const char * debug_format_message( const char * format, va_list vargs )
         result = vsnprintf( buf, sz, format, args );
         #endif
         va_end( args );
+        if ( 0 <= result && result < sz )
+	    return buf;
+        free( buf );
         if ( result < 0 )
             return 0;
-        if ( result < sz ) return buf;
-        free( buf );
         sz = result + 1;
     }
 }


### PR DESCRIPTION
If vsnprintf returns -1 then the buffer should be freed before returning.