### PR TITLE
Fix clang-win name mangling

### DIFF
--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -918,6 +918,7 @@ local rule toolset-tag ( name : type ? : property-set )
             {
                case darwin : tag += clang-darwin ;
                case linux  : tag += clang ;
+               case win    : tag += clangw ;
             }
         }
         case como* : tag += como ;
@@ -975,7 +976,7 @@ local rule toolset-tag ( name : type ? : property-set )
     }
 
     # Ditto, from Clang 4
-    if $(tag) = clang && [ numbers.less 3 $(version[1]) ]
+    if $(tag) in clang clangw && [ numbers.less 3 $(version[1]) ]
     {
         version = $(version[1]) ;
     }


### PR DESCRIPTION
It previously had no tag, so f.ex. Clang 6.0.1 just added "-60" to the mangled name instead of "-clangw6" as now.