### PR TITLE
Fix compilation issue on some old compilers

### DIFF
--- a/src/engine/execnt.c
+++ b/src/engine/execnt.c
@@ -766,6 +766,7 @@ static void read_pipe
 {
     DWORD bytesInBuffer = 0;
     DWORD bytesAvailable = 0;
+    int i;
 
     for (;;)
     {
@@ -780,7 +781,6 @@ static void read_pipe
             return;
 
         /* Clean up some illegal chars. */
-        int i;
         for ( i = 0; i < bytesInBuffer; ++i )
         {
             if ( ( (unsigned char)ioBuffer[ i ] < 1 ) )


### PR DESCRIPTION
Failing to compile for VS20018 and VS2013. This should fix it (tested for VS2008).

Thanks