### PR TITLE
Fix clang-pch implementation to actually use pch instead of pth.

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -85,47 +85,47 @@ toolset.flags clang-linux.link OPTIONS <threading>multi/<target-os>windows : -pt
 # C and C++ compilation
 
 rule compile.c++ ( targets * : sources * : properties * ) {
-  local pth-file = [ on $(<) return $(PCH_FILE) ] ;
+  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
 
-  if $(pth-file) {
-    DEPENDS $(<) : $(pth-file) ;
+  if $(pch-file) {
+    DEPENDS $(<) : $(pch-file) ;
     clang-linux.compile.c++.with-pch $(targets) : $(sources) ;
   }
   else {
-    clang-linux.compile.c++.without-pth $(targets) : $(sources) ;
+    clang-linux.compile.c++.without-pch $(targets) : $(sources) ;
   }
 }
 
-actions compile.c++.without-pth {
+actions compile.c++.without-pch {
   "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -o "$(<)" "$(>)"
 }
 
 actions compile.c++.with-pch bind PCH_FILE
 {
-  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pth -Xclang "$(PCH_FILE)" -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -o "$(<)" "$(>)"
 }
 
 rule compile.c ( targets * : sources * : properties * )
 {
-  local pth-file = [ on $(<) return $(PCH_FILE) ] ;
+  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
 
-  if $(pth-file) {
-    DEPENDS $(<) : $(pth-file) ;
+  if $(pch-file) {
+    DEPENDS $(<) : $(pch-file) ;
     clang-linux.compile.c.with-pch $(targets) : $(sources) ;
   }
   else {
-    clang-linux.compile.c.without-pth $(targets) : $(sources) ;
+    clang-linux.compile.c.without-pch $(targets) : $(sources) ;
   }
 }
 
-actions compile.c.without-pth
+actions compile.c.without-pch
 {
   "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 actions compile.c.with-pch bind PCH_FILE
 {
-  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pth -Xclang "$(PCH_FILE)" -c -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -c -o "$(<)" "$(>)"
 }
 
 ###############################################################################
@@ -137,7 +137,7 @@ rule compile.c++.pch ( targets * : sources * : properties * ) {
 }
 
 actions compile.c++.pch {
-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 rule compile.c.pch ( targets * : sources * : properties * ) {
@@ -145,7 +145,7 @@ rule compile.c.pch ( targets * : sources * : properties * ) {
 
 actions compile.c.pch
 {
-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
+  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 ###############################################################################


### PR DESCRIPTION
As listed in issue #367, PTH is/was an undocumented experimental feature of
clang that is considered 'failed' and is currently being removed from
the next version of clang.  Additionally, there is a bug in the
implementation of PTH in clang that results in severe miscompilation of
code using about 1/3 of the available tokens.

This patch replaces PTH with PCH, which completely subsumes PTH's
functionality. Additionally, PCH mode on clang should now be faster as a
result.

For edification: The difference between PTH and PCH is which step the
compiler stops to save to the binary file.  PTH was intended to execute
after the preprocessor has executed and commits the token list to the
binary file.  PCH will go through semantic analysis and commit the AST
to the binary file.