### PR TITLE
add clang to the list of supported toolsets for bootstrap.sh

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -31,8 +31,9 @@ error_exit ()
     echo "###     ./build.sh gcc"
     echo "###"
     echo "### Toolsets supported by this script are:"
-    echo "###     acc, como, darwin, gcc, intel-darwin, intel-linux, kcc, kylix,"
-    echo "###     mipspro, pathscale, pgi, qcc, sun, sunpro, tru64cxx, vacpp"
+    echo "###     acc, clang, como, darwin, gcc, intel-darwin, intel-linux,"
+    echo "###     kcc, kylix, mipspro, pathscale, pgi, qcc, sun, sunpro,"
+    echo "###     tru64cxx, vacpp"
     echo "###"
     echo "### A special toolset; cc, is available which is used as a fallback"
     echo "### when a more specific toolset is not found and the cc command is"
@@ -79,6 +80,7 @@ Guess_Toolset ()
     elif test_uname AIX && test_path xlc; then BOOST_JAM_TOOLSET=vacpp    
     elif test_uname FreeBSD && test_path freebsd-version && test_path clang; then BOOST_JAM_TOOLSET=clang
     elif test_path gcc ; then BOOST_JAM_TOOLSET=gcc
+    elif test_path clang ; then BOOST_JAM_TOOLSET=clang
     elif test_path icc ; then BOOST_JAM_TOOLSET=intel-linux
     elif test -r /opt/intel/cc/9.0/bin/iccvars.sh ; then
         BOOST_JAM_TOOLSET=intel-linux


### PR DESCRIPTION
clang was not in the list of supported toolsets - it was also missing from the Guess_Toolset script so I slotted it in under gcc.  This means when guessing we will prefer gcc, then clang.  It is better than missing clang all together and being unable to guess.

clang is detected a couple lines earlier for FreeBSD, which means if you are on FreeBSD and you have clang it is used, otherwise gcc.  I'm not sure this is really necessary here, but I didn't change it.