### PR TITLE
The --version option does not exist for versions of clang-cl earlier …

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -74,7 +74,7 @@ rule init ( version ? : command * : options * )
     local compiler = "\"$(command)\"" ;
     compiler = "$(compiler:J= )" ;
 
-    version ?= [ MATCH "version ([0-9.]+)" : [ SHELL "$(compiler) --version" ] ] ;
+    version ?= [ MATCH "version ([0-9.]+)" : [ SHELL "$(compiler) -v" ] ] ;
 
     .notice "using compiler '$(compiler)', version '$(version)'" ;
 


### PR DESCRIPTION
…than 6.0.