### PR TITLE
Fix clang version check; the `in` operator is true when $tag is undef…

### DIFF
--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -976,7 +976,7 @@ local rule toolset-tag ( name : type ? : property-set )
     }
 
     # Ditto, from Clang 4
-    if $(tag) in clang clangw && [ numbers.less 3 $(version[1]) ]
+    if ( $(tag) = clang || $(tag) = clangw ) && [ numbers.less 3 $(version[1]) ]
     {
         version = $(version[1]) ;
     }


### PR DESCRIPTION
…ined