### PR TITLE
Test the feature.valid to show that it succeeds and how to use it.

### DIFF
--- a/src/build/feature.jam
+++ b/src/build/feature.jam
@@ -1330,6 +1330,13 @@ rule __test__ ( )
         : add-defaults <runtime-link>static <define>foobar <optimization>on
           <fu>fu1 ;
 
+    feature f0 : f0-0 f0-1 ;
+    feature f1 : f1-0 f1-1 ;
+
+    assert.true valid <f0> ;
+    assert.true valid <f1> ;
+    assert.true valid <f0> <f1> ;
+
     set-default <runtime-link> : static ;
     assert.result <runtime-link>static : defaults <runtime-link> ;
 


### PR DESCRIPTION
This pull request just adds some tests for the `feature.valid` rule.  I added this as I had made a mistake in using the rule in some of my own code and thought I had found a bug.  This test will also show users how to use this rule (if they read the source).

I was using this rule to adding a workaround for `<cxxstd>` in older versions of Boost.Build, such as exist in Debian 9 versions of Boost.Build.

The workaround is terrible and looks something like the following.  There's almost certainly a cleaner way to do this, but I'm just using it as an example for using `feature.valid` for this pull request.

```
# cxxstd-feature-workaround.jam
import feature ;

cxxstd-requirements = ;

if ! [ feature.valid <cxxstd> ]
{
  feature.feature cxxstd : 98 11 14 17 2a : optional composite propagated ;

  cxxstd-requirements =
    "<cxxstd>98,<toolset>darwin:<cxxflags>-std=c++03"
    "<cxxstd>98,<toolset>gcc:<cxxflags>-std=c++03"
    "<cxxstd>98,<toolset>clang:<cxxflags>-std=c++03"
    "<cxxstd>11,<toolset>darwin:<cxxflags>-std=c++11"
    "<cxxstd>11,<toolset>gcc:<cxxflags>-std=c++11"
    "<cxxstd>11,<toolset>clang:<cxxflags>-std=c++11"
    "<cxxstd>14,<toolset>msvc:<cxxflags>/std:c++14"
    "<cxxstd>14,<toolset>darwin:<cxxflags>-std=c++14"
    "<cxxstd>14,<toolset>gcc:<cxxflags>-std=c++14"
    "<cxxstd>14,<toolset>clang:<cxxflags>-std=c++14"
    "<cxxstd>17,<toolset>msvc:<cxxflags>/std:c++17"
    "<cxxstd>17,<toolset>darwin:<cxxflags>-std=c++17"
    "<cxxstd>17,<toolset>gcc:<cxxflags>-std=c++17"
    "<cxxstd>17,<toolset>clang:<cxxflags>-std=c++17"
    "<cxxstd>2a,<toolset>msvc:<cxxflags>/std:latest"
    "<cxxstd>2a,<toolset>darwin:<cxxflags>-std=c++2a"
    "<cxxstd>2a,<toolset>gcc:<cxxflags>-std=c++2a"
    "<cxxstd>2a,<toolset>clang:<cxxflags>-std=c++2a"
    ;
}
```

```
import cxxstd-feature-workaround ;

project : requirements $(cxxstd-requirements) ;
```
