### PR TITLE
Fix scanner regex pattern

### DIFF
--- a/src/engine/headers.c
+++ b/src/engine/headers.c
@@ -139,7 +139,7 @@ LIST * headers1( LIST * l, OBJECT * file, int rec, regexp * re[] )
     if ( re_macros == 0 )
     {
         OBJECT * const re_str = object_new(
-            "#[ \t]*include[ \t]*([A-Za-z][A-Za-z0-9_]*).*$" );
+            "^[ \t]*#[ \t]*include[ \t]*([A-Za-z][A-Za-z0-9_]*).*$" );
         re_macros = regex_compile( re_str );
         object_free( re_str );
     }

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -364,7 +364,7 @@ class CScanner (scanner.Scanner):
             self.includes_.extend(i.split("&&"))
 
     def pattern (self):
-        return r'#[ \t]*include[ ]*(<(.*)>|"(.*)")'
+        return r'^[ \t]*#[ \t]*include[ ]*(<(.*)>|"(.*)")'
 
     def process (self, target, matches, binding):
         # since it's possible for this function to be called

--- a/src/tools/midl.jam
+++ b/src/tools/midl.jam
@@ -46,14 +46,14 @@ class midl-scanner : scanner
         self.re-importlib = "importlib[ \t]*[(]"$(self.re-strings)"[)][ \t]*;" ;
 
         # C preprocessor 'include' directive
-        self.re-include-angle  = "#[ \t]*include[ \t]*<(.*)>" ;
-        self.re-include-quoted = "#[ \t]*include[ \t]*\"(.*)\"" ;
+        self.re-include-angle  = "^[ \t]*#[ \t]*include[ \t]*<(.*)>" ;
+        self.re-include-quoted = "^[ \t]*#[ \t]*include[ \t]*\"(.*)\"" ;
     }    
 
     rule pattern ( )
     {
         # Match '#include', 'import' and 'importlib' directives
-        return "((#[ \t]*include|import(lib)?).+(<(.*)>|\"(.*)\").+)" ;
+        return "^[ \t]*((#[ \t]*include|import(lib)?).+(<(.*)>|\"(.*)\").+)" ;
     }
 
     rule process ( target : matches * : binding )

--- a/src/tools/midl.py
+++ b/src/tools/midl.py
@@ -38,12 +38,12 @@ class MidlScanner(scanner.Scanner):
         self.re_importlib = "importlib[ \t]*[(]" + re_strings + "[)][ \t]*;" ;
 
         # C preprocessor 'include' directive
-        self.re_include_angle  = "#[ \t]*include[ \t]*<(.*)>" ;
-        self.re_include_quoted = "#[ \t]*include[ \t]*\"(.*)\"" ;
+        self.re_include_angle  = "^[ \t]*#[ \t]*include[ \t]*<(.*)>" ;
+        self.re_include_quoted = "^[ \t]*#[ \t]*include[ \t]*\"(.*)\"" ;
 
     def pattern():
         # Match '#include', 'import' and 'importlib' directives
-        return "((#[ \t]*include|import(lib)?).+(<(.*)>|\"(.*)\").+)"
+        return "^[ \t]*((#[ \t]*include|import(lib)?).+(<(.*)>|\"(.*)\").+)"
 
     def process(self, target, matches, binding):
         included_angle  = regex.transform(matches, self.re_include_angle)

--- a/src/tools/types/cpp.jam
+++ b/src/tools/types/cpp.jam
@@ -30,7 +30,7 @@ class c-scanner : scanner
 
     rule pattern ( )
     {
-        return "#[ \t]*include[ \t]*(<(.*)>|\"(.*)\")" ;
+        return "^[ \t]*#[ \t]*include[ \t]*(<(.*)>|\"(.*)\")" ;
     }
 
     rule process ( target : matches * : binding )

--- a/src/tools/types/objc.jam
+++ b/src/tools/types/objc.jam
@@ -14,7 +14,7 @@ class objc-scanner : c-scanner
 
     rule pattern ( )
     {
-        return "#[ \t]*include|import[ ]*(<(.*)>|\"(.*)\")" ;
+        return "^[ \t]*#[ \t]*include|import[ ]*(<(.*)>|\"(.*)\")" ;
     }
 }
 


### PR DESCRIPTION
Before, commented includes are added as dependencies

```cpp
#include "a.h" // recompiled if a.h is updated: ok
// #include "b.h" // recompiled if b.h is updated: bad
int main() {}
```

The new pattern checks that `#` is preceded by 0 or more blank characters