### PR TITLE
Handle <asmflags> in common

### DIFF
--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -429,6 +429,7 @@ local rule check-tool ( xcommand + )
 # - OPTIONS for compile         to the value of <compileflags> in $(options)
 # - OPTIONS for compile.c       to the value of <cflags>       in $(options)
 # - OPTIONS for compile.c++     to the value of <cxxflags>     in $(options)
+# - OPTIONS for compile.asm     to the value of <asmflags>     in $(options)
 # - OPTIONS for compile.fortran to the value of <fflags>       in $(options)
 # - OPTIONS for link            to the value of <linkflags>    in $(options)
 #
@@ -453,6 +454,9 @@ rule handle-options ( toolset : condition * : command * : options * )
 
     toolset.flags $(toolset).compile.c++     OPTIONS $(condition) :
         [ feature.get-values <cxxflags>     : $(options) ] : unchecked ;
+
+    toolset.flags $(toolset).compile.asm     OPTIONS $(condition) :
+        [ feature.get-values <asmflags>     : $(options) ] : unchecked ;
 
     toolset.flags $(toolset).compile.fortran OPTIONS $(condition) :
         [ feature.get-values <fflags>       : $(options) ] : unchecked ;

--- a/src/tools/common.py
+++ b/src/tools/common.py
@@ -441,6 +441,7 @@ def handle_options(tool, condition, command, options):
         - OPTIOns for compile to the value of <compileflags> in options
         - OPTIONS for compile.c to the value of <cflags> in options
         - OPTIONS for compile.c++ to the value of <cxxflags> in options
+        - OPTIONS for compile.asm to the value of <asmflags> in options
         - OPTIONS for compile.fortran to the value of <fflags> in options
         - OPTIONs for link to the value of <linkflags> in options
     """
@@ -454,6 +455,7 @@ def handle_options(tool, condition, command, options):
     toolset.flags(tool + '.compile', 'OPTIONS', condition, feature.get_values('<compileflags>', options))
     toolset.flags(tool + '.compile.c', 'OPTIONS', condition, feature.get_values('<cflags>', options))
     toolset.flags(tool + '.compile.c++', 'OPTIONS', condition, feature.get_values('<cxxflags>', options))
+    toolset.flags(tool + '.compile.asm', 'OPTIONS', condition, feature.get_values('<asmflags>', options))
     toolset.flags(tool + '.compile.fortran', 'OPTIONS', condition, feature.get_values('<fflags>', options))
     toolset.flags(tool + '.link', 'OPTIONS', condition, feature.get_values('<linkflags>', options))
 


### PR DESCRIPTION
They were not forwarded in compile.asm actions, which prevented
cross-build scenarii.

Will most likely close https://github.com/conan-community/community/issues/139