### PR TITLE
Fix build with Embarcadero C++ Builder ("borland" toolset)

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -100,8 +100,8 @@ if errorlevel 1 (
 
 call guess_toolset.bat
 if errorlevel 1 (
-    call :Error_Print "Could not find a suitable toolset."
-    goto :eof)
+    call :Error_Print "Could not find a suitable toolset.")
+goto :eof
 
 
 :Guess_Yacc

--- a/src/engine/build.jam
+++ b/src/engine/build.jam
@@ -176,7 +176,7 @@ toolset acc cc : "-o " : -D
     -I$(--python-include) -I$(--extra-include)
     : -L$(--python-lib[1]) -l$(--python-lib[2]) ;
 ## Borland C++ 5.5.x
-toolset borland bcc32 : -e -n : /D
+toolset borland bcc32 : -e -n : "-Nd /D" " /D" ""
     : -WC -w- -q "-I$(toolset-root)Include" "-L$(toolset-root)Lib"
     [ opt --release : -O2 -vi -w-inl ]
     [ opt --debug : -v -Od -vi- ]
@@ -688,7 +688,7 @@ else if ! $(--def[2]) { actions "[COMPILE]" {
     "$(--cc)" "$(--bin)$(<:D=)" "$(--dir)$(<:D)$(./)" $(--out)$(<) "$(--def)$(--defs)" "$(--flags)" "$(>)" "$(--libs)"
 } }
 else { actions "[COMPILE]" {
-    "$(--cc)" "$(--bin)$(<:D=)" "$(--dir)$(<:D)$(./)" $(--out)$(<) "$(--def[1])$(--defs:J=$(--def[2]))$(--def[3])" "$(--flags)"  "$(>)" "$(--libs)"
+    "$(--cc)" "$(--bin)$(<:D=)" "$(--dir)$(<:D)$(./)" $(--out)$(<) $(--def[1])$(--defs:J=$(--def[2]))$(--def[3]) "$(--flags)"  "$(>)" "$(--libs)"
 } }
 
 if $(OS) = VMS { actions "[COMPILE.LINK]" {

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -184,7 +184,7 @@ set "_known_=1"
 :Skip_VC141
 if NOT "_%BOOST_JAM_TOOLSET%_" == "_borland_" goto Skip_BORLAND
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
-    call :Test_Path bcc32.exe )
+    call guess_toolset.bat test_path bcc32.exe )
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     if not errorlevel 1 (
         set "BOOST_JAM_TOOLSET_ROOT=%FOUND_PATH%..\"

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -192,7 +192,7 @@ if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
 if not "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     set "PATH=%BOOST_JAM_TOOLSET_ROOT%Bin;%PATH%"
     )
-set "BOOST_JAM_CC=bcc32 -WC -w- -q -I%BOOST_JAM_TOOLSET_ROOT%Include -L%BOOST_JAM_TOOLSET_ROOT%Lib /DNT -nbootstrap"
+set "BOOST_JAM_CC=bcc32 -WC -w- -q -I"%BOOST_JAM_TOOLSET_ROOT%Include" -L"%BOOST_JAM_TOOLSET_ROOT%Lib" /DNT -nbootstrap"
 set "BOOST_JAM_OPT_JAM=-ejam0"
 set "BOOST_JAM_OPT_MKJAMBASE=-emkjambasejam0"
 set "BOOST_JAM_OPT_YYACC=-eyyacc0"

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -192,7 +192,7 @@ if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
 if not "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     set "PATH=%BOOST_JAM_TOOLSET_ROOT%Bin;%PATH%"
     )
-set "BOOST_JAM_CC=bcc32 -WC -w- -q -I"%BOOST_JAM_TOOLSET_ROOT%Include" -L"%BOOST_JAM_TOOLSET_ROOT%Lib" /DNT -nbootstrap"
+set "BOOST_JAM_CC=bcc32 -WC -w- -q -I"%BOOST_JAM_TOOLSET_ROOT%Include" -L"%BOOST_JAM_TOOLSET_ROOT%Lib" -Nd /DNT -nbootstrap"
 set "BOOST_JAM_OPT_JAM=-ejam0"
 set "BOOST_JAM_OPT_MKJAMBASE=-emkjambasejam0"
 set "BOOST_JAM_OPT_YYACC=-eyyacc0"

--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -5,6 +5,9 @@ REM ~ Distributed under the Boost Software License, Version 1.0.
 REM ~ (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
 if "_%1_" == "_yacc_" goto Guess_Yacc
+if "_%1_" == "_test_path_" (
+    shift
+    goto Test_Path)
 goto Guess
 
 


### PR DESCRIPTION
Fix several problems with building with the `borland` toolset on a Embarcadero C++ Builder 10.3.1 ([Community Edition](https://www.embarcadero.com/products/cbuilder/starter)) installation:

 - `bootstrap.bat` -> `src/engine/build.bat` bypasses loading `src/engine/guess_toolset.bat` if an override toolset is given. This later leads to the call to `Test_Path` failing. (Issue #382)
 - C++Builder toolchain path is intolerant of spaces, e.g. `C:\Program Files\Embarcadero\…`
 - Old Borland (`bcc32.exe`) preprocessor doesn't accept `#if SYMBOL_NAME`, but insists on `#if defined(SYMBOL_NAME)` or `#ifdef SYMBOL_NAME`. Work around this by providing `-Nd` to auto-define `SYMBOL_NAME` to `1`.

With these three fixes, running `bootstrap.bat borland` in the super-project directory should successfully produce a working `b2.exe`.

NOTE: To actually build some Boost libraries with the `borland` toolset, we also need a `user-config.jam` file to force the use of `bcc32c.exe` for modern C++ support:

```
using borland : 7.40 : bcc32c.exe -DBOOST_STRICT_CONFIG -DBOOST_ASSERT_CONFIG ;
```

(I've [managed to build](https://github.com/tanzislam/cryptopals/wiki/Importing-into-Embarcadero-C┼┼Builder-Starter-10.2#linking-in-a-boost-library) Boost.System, Boost.DateTime and Boost.Regex in this manner.)