### PR TITLE
Support for Visual Studio 2019 (msvc-14.2)

### DIFF
--- a/src/engine/build.jam
+++ b/src/engine/build.jam
@@ -408,6 +408,13 @@ toolset vc141 cl : /Fe /Fe /Fd /Fo : -D
     [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]
     -I$(--python-include) -I$(--extra-include)
     : kernel32.lib advapi32.lib user32.lib $(--python-lib[1]) ;
+## Microsoft Visual C++ 2019
+toolset vc142 cl : /Fe /Fe /Fd /Fo : -D
+    : /nologo
+    [ opt --release : /GL /MT /O2 /Ob2 /Gy /GF /GA /wd4996 ]
+    [ opt --debug : /MTd /DEBUG /Z7 /Od /Ob0 /wd4996 ]
+    -I$(--python-include) -I$(--extra-include)
+    : kernel32.lib advapi32.lib user32.lib $(--python-lib[1]) ;
 ## VMS/OpenVMS DEC C
 toolset vmsdecc cc : /OBJECT= : "/DEFINES=(" "," ")"
     : /STANDARD=VAXC /PREFIX_LIBRARY_ENTRIES=(ALL_ENTRIES)

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -182,6 +182,50 @@ set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
 set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
 set "_known_=1"
 :Skip_VC141
+if NOT "_%BOOST_JAM_TOOLSET%_" == "_vc142_" goto Skip_VC142
+call vswhere_usability_wrapper.cmd
+REM Reset ERRORLEVEL since from now on it's all based on ENV vars
+ver > nul 2> nul
+if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
+    if NOT "_%VS160COMNTOOLS%_" == "__" (
+        set "BOOST_JAM_TOOLSET_ROOT=%VS160COMNTOOLS%..\..\VC\"
+    ))
+
+if "_%BOOST_JAM_ARCH%_" == "__" set BOOST_JAM_ARCH=x86
+set BOOST_JAM_ARGS=%BOOST_JAM_ARGS% %BOOST_JAM_ARCH%
+
+REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\Source if it exists.
+pushd %CD%
+if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %BOOST_JAM_ARGS%
+popd
+set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
+set "BOOST_JAM_OPT_JAM=/Febootstrap\jam0"
+set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
+set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
+set "_known_=1"
+:Skip_VC142
+if NOT "_%BOOST_JAM_TOOLSET%_" == "_vcunk_" goto Skip_VCUNK
+call vswhere_usability_wrapper.cmd
+REM Reset ERRORLEVEL since from now on it's all based on ENV vars
+ver > nul 2> nul
+if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
+    if NOT "_%VSUNKCOMNTOOLS%_" == "__" (
+        set "BOOST_JAM_TOOLSET_ROOT=%VSUNKCOMNTOOLS%..\..\VC\"
+    ))
+
+if "_%BOOST_JAM_ARCH%_" == "__" set BOOST_JAM_ARCH=x86
+set BOOST_JAM_ARGS=%BOOST_JAM_ARGS% %BOOST_JAM_ARCH%
+
+REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\Source if it exists.
+pushd %CD%
+if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%BOOST_JAM_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %BOOST_JAM_ARGS%
+popd
+set "BOOST_JAM_CC=cl /nologo /RTC1 /Zi /MTd /Fobootstrap/ /Fdbootstrap/ -DNT -DYYDEBUG -wd4996 kernel32.lib advapi32.lib user32.lib"
+set "BOOST_JAM_OPT_JAM=/Febootstrap\jam0"
+set "BOOST_JAM_OPT_MKJAMBASE=/Febootstrap\mkjambase0"
+set "BOOST_JAM_OPT_YYACC=/Febootstrap\yyacc0"
+set "_known_=1"
+:Skip_VCUNK
 if NOT "_%BOOST_JAM_TOOLSET%_" == "_borland_" goto Skip_BORLAND
 if "_%BOOST_JAM_TOOLSET_ROOT%_" == "__" (
     call guess_toolset.bat test_path bcc32.exe )

--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -36,6 +36,14 @@ if NOT "_%VS150COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET=vc141"
     set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"
     goto :eof)
+if NOT "_%VS160COMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET=vc142"
+    set "BOOST_JAM_TOOLSET_ROOT=%VS160COMNTOOLS%..\..\VC\"
+    goto :eof)
+if NOT "_%VSUNKCOMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET=vcunk"
+    set "BOOST_JAM_TOOLSET_ROOT=%VSUNKCOMNTOOLS%..\..\VC\"
+    goto :eof)
 
 :skip_vswhere
 call :Clear_Error

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -40,8 +40,8 @@ for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     exit /B 0
 )
 
-REM Visual Studio Next (17.X, toolset 14.3???)
-set VSWHERE_LMT=-version "[17.0,18.0)"
+REM Visual Studio Unknown Version, Beyond 2019
+set VSWHERE_LMT=-version "[17.0)"
 set VSWHERE_PRERELEASE=-prerelease
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT% %VSWHERE_PRERELEASE%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
@@ -49,7 +49,7 @@ for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
 	echo Found with vswhere %%i
     @rem comment out setting VCINSTALLDIR for Boost.build
     @rem set "VCINSTALLDIR=%%i\VC\"
-    set "VS170COMNTOOLS=%%i\Common7\Tools\"
+    set "VSUNKCOMNTOOLS=%%i\Common7\Tools\"
     exit /B 0
 )
 

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -1,7 +1,8 @@
 :: Copyright 2017 - Refael Ackermann
+:: Copyright 2019 - Thomas Kent
 :: Distributed under MIT style license
 :: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
-:: version: 1.15.4
+:: Forked from version: 1.15.4
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
@@ -14,16 +15,41 @@ where vswhere 2> nul > nul
 if errorlevel 1 goto :no-vswhere
 set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 set VSWHERE_PRP=-property installationPath
+
+REM Visual Studio 2017 (15.X, toolset 14.1)
 set VSWHERE_LMT=-version "[15.0,16.0)"
-vswhere -prerelease > nul
-if "%~1"=="prerelase" set VSWHERE_WITH_PRERELASE=1
-if not errorlevel 1 if "%VSWHERE_WITH_PRERELASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     endlocal
+	echo Found with vswhere %%i
     @rem comment out setting VCINSTALLDIR for Boost.build
     @rem set "VCINSTALLDIR=%%i\VC\"
     set "VS150COMNTOOLS=%%i\Common7\Tools\"
+    exit /B 0
+)
+
+REM Visual Studio 2019 (16.X, toolset 14.2)
+set VSWHERE_LMT=-version "[16.0,17.0)"
+SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
+for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
+    endlocal
+	echo Found with vswhere %%i
+    @rem comment out setting VCINSTALLDIR for Boost.build
+    @rem set "VCINSTALLDIR=%%i\VC\"
+    set "VS160COMNTOOLS=%%i\Common7\Tools\"
+    exit /B 0
+)
+
+REM Visual Studio Next (17.X, toolset 14.3???)
+set VSWHERE_LMT=-version "[17.0,18.0)"
+set VSWHERE_PRERELEASE=-prerelease
+SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT% %VSWHERE_PRERELEASE%
+for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
+    endlocal
+	echo Found with vswhere %%i
+    @rem comment out setting VCINSTALLDIR for Boost.build
+    @rem set "VCINSTALLDIR=%%i\VC\"
+    set "VS170COMNTOOLS=%%i\Common7\Tools\"
     exit /B 0
 )
 

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -21,6 +21,7 @@ http://msdn.microsoft.com/visualc/[Microsoft Visual C++] command-line
 tools on Microsoft Windows. The supported products and versions of
 command line tools are listed below:
 
+* Visual Studio 2019-14.2
 * Visual Studio 2017—14.1
 * Visual Studio 2015—14.0
 * Visual Studio 2013—12.0
@@ -37,7 +38,7 @@ equal to `msvc-[version number]` for example to build with Visual Studio
 2017 one could run:
 
 ----
-.\b2 toolset=msvc-14.1 target
+.\b2 toolset=msvc-14.2 target
 ----
 
 The `msvc` module is initialized using the following syntax:
@@ -1015,7 +1016,15 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
         }
         else
         {
-            if [ MATCH "(14.1)" : $(version) ]
+            if [ MATCH "(14.2)" : $(version) ]
+            {
+                if $(.debug-configuration)
+                {
+                    ECHO 'notice\: "[generate-setup-cmd]" $(version) is 14.2' ;
+                }
+                parent = [ path.native [ path.join  $(parent) "..\\..\\..\\..\\..\\Auxiliary\\Build" ] ] ;
+            }
+            else if [ MATCH "(14.1)" : $(version) ]
             {
                 if $(.debug-configuration)
                 {
@@ -1173,9 +1182,9 @@ local rule configure-really ( version ? : options * )
 
         local command = [ feature.get-values <command> : $(options) ] ;
 
-        # For 14.1 we need the exact version as MS is planning rolling updates
+        # For 14.1+ we need the exact version as MS is planning rolling updates
         # that will cause our `setup-cmd` to become invalid
-        exact-version = [ MATCH "(14\.10\.[0-9\.]+)" : $(command) ] ;
+        exact-version = [ MATCH "(14\.[1-9][0-9]\.[0-9\.]+)" : $(command) ] ;
 
         # If version is specified, we try to search first in default paths, and
         # only then in PATH.
@@ -1204,7 +1213,11 @@ local rule configure-really ( version ? : options * )
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if [ MATCH "(MSVC\\14.1)" : $(command) ]
+            if [ MATCH "(MSVC\\14.2)" : $(command) ]
+            {
+                version = 14.2 ;
+            }
+            else if [ MATCH "(MSVC\\14.1)" : $(command) ]
             {
                 version = 14.1 ;
             }
@@ -1533,8 +1546,26 @@ local rule default-path ( version )
     else
     {
         # try to use vswhere
-        local pseudo_env_VS150 ;
-        if $(version) = 14.1 || $(version) = "default"
+        local pseudo_env_VSCOMNTOOLS ;
+        if $(version) = 14.2 || $(version) = "default"
+        {
+            local req = "-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64" ;
+            local prop = "-property installationPath" ;
+            local limit = "-version \"[16.0,17.0)\"" ;
+            local root = [ os.environ "ProgramFiles(x86)" ] ;
+            if ( ! $(root) )
+            {
+                root = [ os.environ "ProgramFiles" ] ;
+            }
+            local vswhere = "$(root)\\Microsoft Visual Studio\\Installer\\vswhere.exe" ;
+            if ( [ path.exists $(vswhere) ] )
+            {
+                local vmwhere_cmd = "\"$(vswhere)\" -latest -products * $(req) $(prop) $(limit)" ;
+                local shell_ret = [ SPLIT_BY_CHARACTERS [ SHELL $(vmwhere_cmd) ] : "\n" ] ;
+                pseudo_env_VSCOMNTOOLS = [ path.native [ path.join $(shell_ret) "\\Common7\\Tools" ] ] ;
+            }
+        }
+        else if $(version) = 14.1
         {
             local req = "-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64" ;
             local prop = "-property installationPath" ;
@@ -1549,7 +1580,7 @@ local rule default-path ( version )
             {
                 local vmwhere_cmd = "\"$(vswhere)\" -latest -products * $(req) $(prop) $(limit)" ;
                 local shell_ret = [ SPLIT_BY_CHARACTERS [ SHELL $(vmwhere_cmd) ] : "\n" ] ;
-                pseudo_env_VS150 = [ path.native [ path.join $(shell_ret) "\\Common7\\Tools" ] ] ;
+                pseudo_env_VSCOMNTOOLS = [ path.native [ path.join $(shell_ret) "\\Common7\\Tools" ] ] ;
             }
         }
 
@@ -1557,9 +1588,9 @@ local rule default-path ( version )
         for local env in $(.version-$(version)-env)
         {
             local env-path ;
-            if ( $(pseudo_env_VS150) && [ path.exists $(pseudo_env_VS150) ] )
+            if ( $(pseudo_env_VSCOMNTOOLS) && [ path.exists $(pseudo_env_VSCOMNTOOLS) ] )
             {
-                env-path = $(pseudo_env_VS150) ;
+                env-path = $(pseudo_env_VSCOMNTOOLS) ;
             }
             else
             {
@@ -1956,7 +1987,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
                      armv7 armv7s ;
 
 # Known toolset versions, in order of preference.
-.known-versions = 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
+.known-versions = 14.2 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
     7.1toolkit 7.0 6.0 ;
 
 # Version aliases.
@@ -1970,6 +2001,7 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 .version-alias-12 = 12.0 ;
 .version-alias-14 = 14.0 ;
 .version-alias-14.1 = 14.1 ;
+.version-alias-14.2 = 14.2 ;
 
 # Names of registry keys containing the Visual C++ installation path (relative
 # to "HKEY_LOCAL_MACHINE\SOFTWARE\\Microsoft").
@@ -1999,6 +2031,11 @@ if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
     "Microsoft Visual Studio/2017/*/VC/Tools/MSVC/*/bin/Host*/*"
     ;
 .version-14.1-env = VS150COMNTOOLS ProgramFiles ProgramFiles(x86) ;
+.version-14.2-path =
+    "../../VC/Tools/MSVC/*/bin/Host*/*"
+    "Microsoft Visual Studio/2017/*/VC/Tools/MSVC/*/bin/Host*/*"
+    ;
+.version-14.2-env = VS150COMNTOOLS ProgramFiles ProgramFiles(x86) ;
 
 # Auto-detect all the available msvc installations on the system.
 auto-detect-toolset-versions ;


### PR DESCRIPTION
This is the smallest of starts to providing VS 2019 support. This fixes the vswhere_usability_wrapper.cmd that is called by build.cmd/guess_toolset.cmd. It doesn't include the fixes that are needed to use the VS160COMNTOOLS env variable.