### PR TITLE
If the vswhere lookup fails, keep searching for others

### DIFF
--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -32,21 +32,20 @@ goto :eof
 REM Check the variable first. This can be set manually by the user (by running the tools command prompt).
 call :Clear_Error
 call vswhere_usability_wrapper.cmd
-if NOT "_%VS150COMNTOOLS%_" == "__" (
-    set "BOOST_JAM_TOOLSET=vc141"
-    set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"
+call :Clear_Error
+REM VSUNKCOMNTOOLS represents unknown but detected version from vswhere
+if NOT "_%VSUNKCOMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET=vcunk"
+    set "BOOST_JAM_TOOLSET_ROOT=%VSUNKCOMNTOOLS%..\..\VC\"
     goto :eof)
 if NOT "_%VS160COMNTOOLS%_" == "__" (
     set "BOOST_JAM_TOOLSET=vc142"
     set "BOOST_JAM_TOOLSET_ROOT=%VS160COMNTOOLS%..\..\VC\"
     goto :eof)
-if NOT "_%VSUNKCOMNTOOLS%_" == "__" (
-    set "BOOST_JAM_TOOLSET=vcunk"
-    set "BOOST_JAM_TOOLSET_ROOT=%VSUNKCOMNTOOLS%..\..\VC\"
+if NOT "_%VS150COMNTOOLS%_" == "__" (
+    set "BOOST_JAM_TOOLSET=vc141"
+    set "BOOST_JAM_TOOLSET_ROOT=%VS150COMNTOOLS%..\..\VC\"
     goto :eof)
-
-:skip_vswhere
-call :Clear_Error
 if EXIST "%VS_ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  (
     set "BOOST_JAM_TOOLSET=vc141"
     set "BOOST_JAM_TOOLSET_ROOT=%VS_ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\VC\"

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -56,4 +56,4 @@ for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
 :no-vswhere
 endlocal
 echo could not find "vswhere"
-exit /B 0
+exit /B 1

--- a/src/engine/vswhere_usability_wrapper.cmd
+++ b/src/engine/vswhere_usability_wrapper.cmd
@@ -56,4 +56,4 @@ for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
 :no-vswhere
 endlocal
 echo could not find "vswhere"
-exit /B 1
+exit /B 0


### PR DESCRIPTION
Exiting with a non-zero errorlevel caused it to exit from guess_toolset.cmd, we want it to keep looking for other versions.

How did bootstrap keep working on machines without VS2017/2019 installed?