### PR TITLE
Improve docs.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,6 +23,10 @@ do
       TOOLSET=`expr "x$option" : "x-*with-toolset=\(.*\)"`
       ;;
 
+    -with-b2=* | --with-b2=* )
+      B2=`expr "x$option" : "x-*with-b2=\(.*\)"`
+      ;;    
+
     -*)
       { echo "error: unrecognized option: $option
 Try \`$0 --help' for more information." >&2

--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -11,7 +11,8 @@ Immediately upon starting, the Boost.Build engine (*`b2`*) loads the Jam
 code that implements the build system. To do this, it searches for a
 file called `boost-build.jam`, first in the invocation directory, then
 in its parent and so forth up to the filesystem root, and finally in the
-directories specified by the environment variable BOOST_BUILD_PATH. When
+directories specified by the environment variable BOOST_BUILD_PATH. On
+Unix BOOST_BUILD_PATH defaults to `/usr/share/boost-build`. When
 found, the file is interpreted, and should specify the build system
 location by calling the boost-build rule:
 


### PR DESCRIPTION
 * doc/src/reference.adoc
   (bbv2.reference.init): Mention Unix specific default for `BOOST_BUILD_PATH` (https://github.com/boostorg/build/blob/develop/src/engine/Jambase#L48-L55)