### PR TITLE
win: Increase communication buffers size

### DIFF
--- a/src/engine/execnt.c
+++ b/src/engine/execnt.c
@@ -112,6 +112,9 @@ static void register_wait( int job_id );
  */
 #define MAX_RAW_COMMAND_LENGTH 32766
 
+ /* Communication buffers size */
+#define IO_BUFFER_SIZE ( 64 * 1024 )
+
 /* We hold handles for pipes used to communicate with child processes in two
  * element arrays indexed as follows.
  */
@@ -497,14 +500,14 @@ static void invoke_cmd( char const * const command, int const slot )
 
     /* Create pipes for communicating with the child process. */
     if ( !CreatePipe( &cmdtab[ slot ].pipe_out[ EXECCMD_PIPE_READ ],
-        &cmdtab[ slot ].pipe_out[ EXECCMD_PIPE_WRITE ], &sa, 0 ) )
+        &cmdtab[ slot ].pipe_out[ EXECCMD_PIPE_WRITE ], &sa, IO_BUFFER_SIZE ) )
     {
         reportWindowsError( "CreatePipe", slot );
         return;
     }
     if ( globs.pipe_action && !CreatePipe( &cmdtab[ slot ].pipe_err[
         EXECCMD_PIPE_READ ], &cmdtab[ slot ].pipe_err[ EXECCMD_PIPE_WRITE ],
-        &sa, 0 ) )
+        &sa, IO_BUFFER_SIZE ) )
     {
         reportWindowsError( "CreatePipe", slot );
         return;
@@ -748,8 +751,6 @@ static void record_times( HANDLE const process, timing_info * const time )
     }
 }
 
-
-#define IO_BUFFER_SIZE ( 16 * 1024 )
 
 static char ioBuffer[ IO_BUFFER_SIZE + 1 ];
 


### PR DESCRIPTION
Currently the size of reading buffer is 16KiB while the the pipe buffer is of system default size which seems to be 8KiB on Win7. Because of this the half of the reading buffer is never used.

Also, recent Windows updates with Meltdown mitigation made syscalls more expensive, and increasing the buffer size will lower the syscalls count.

The change is 5x speed-up for me on `b2 -j2 toolset=msvc-10.0 cxxflags=/W4 qi_repo_keywords` (498 -> 106 seconds).