### PR TITLE
generators: Fix an issue in printing usage requirements debug.

### DIFF
--- a/src/build/generators.jam
+++ b/src/build/generators.jam
@@ -1042,7 +1042,7 @@ local rule try-one-generator-really ( project name ? : generator : target-type
     generators.dout [ indent ] " " $(targets) ;
     if $(usage-requirements)
     {
-        generators.dout [ indent ] "  with usage requirements:" $(x) ;
+        generators.dout [ indent ] "  with usage requirements:" $(usage-requirements) ;
     }
 
     if $(success)


### PR DESCRIPTION
This pull request fixes a bug in printing usage requirements when the `--debug-generators` option is enabled.

I've attached a zip file with example Boost.Build project and logs.

```
b2 --debug-generators -a
```

The difference in the logs is shown below.

```diff
97c97
<                with usage requirements:
---
>                with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>debug-symbols <relevant>define <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>link <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors ]
107c107
<            with usage requirements:
---
>            with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>cxxstd <relevant>cxxstd-dialect <relevant>debug-symbols <relevant>define <relevant>dll-path <relevant>find-shared-library <relevant>find-static-library <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>library-file <relevant>library-path <relevant>link <relevant>linkflags <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>runtime-link <relevant>strip <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors <relevant>xdll-path <xdll-path>/private/tmp/tmp/bin/clang-darwin-10.0/debug ]
111c111
<        with usage requirements:
---
>        with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>cxxstd <relevant>cxxstd-dialect <relevant>debug-symbols <relevant>define <relevant>dll-path <relevant>find-shared-library <relevant>find-static-library <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>library-file <relevant>library-path <relevant>link <relevant>linkflags <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>runtime-link <relevant>strip <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors <relevant>xdll-path <xdll-path>/private/tmp/tmp/bin/clang-darwin-10.0/debug ]
140c140
<                with usage requirements:
---
>                with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>debug-symbols <relevant>define <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>link <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors ]
150c150
<            with usage requirements:
---
>            with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>cxxstd <relevant>cxxstd-dialect <relevant>debug-symbols <relevant>define <relevant>dll-path <relevant>find-shared-library <relevant>find-static-library <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>library-file <relevant>library-path <relevant>link <relevant>linkflags <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>runtime-link <relevant>strip <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors <relevant>xdll-path <xdll-path>/private/tmp/tmp/bin/clang-darwin-10.0/debug ]
154c154
<        with usage requirements:
---
>        with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>cxxstd <relevant>cxxstd-dialect <relevant>debug-symbols <relevant>define <relevant>dll-path <relevant>find-shared-library <relevant>find-static-library <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>library-file <relevant>library-path <relevant>link <relevant>linkflags <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>runtime-link <relevant>strip <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors <relevant>xdll-path <xdll-path>/private/tmp/tmp/bin/clang-darwin-10.0/debug ]
238c238
<            with usage requirements:
---
>            with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>debug-symbols <relevant>define <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>link <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors ]
248c248
<        with usage requirements:
---
>        with usage requirements: [ <relevant>address-model <relevant>architecture <relevant>cflags <relevant>cxxstd <relevant>cxxstd-dialect <relevant>debug-symbols <relevant>define <relevant>dll-path <relevant>find-shared-library <relevant>find-static-library <relevant>flags <relevant>include <relevant>inlining <relevant>instruction-set <relevant>library-file <relevant>library-path <relevant>link <relevant>linkflags <relevant>local-visibility <relevant>optimization <relevant>pch <relevant>pch-file <relevant>profiling <relevant>runtime-link <relevant>strip <relevant>target-os <relevant>threading <relevant>toolset <relevant>toolset-clang:platform <relevant>toolset-clang:version <relevant>warnings <relevant>warnings-as-errors <relevant>xdll-path <xdll-path>/private/tmp/tmp/bin/clang-darwin-10.0/debug ]
```

[example.zip](https://github.com/boostorg/build/files/3039644/example.zip)

