### PR TITLE
help: Print help for local modules as well.

### DIFF
--- a/src/options/help.jam
+++ b/src/options/help.jam
@@ -48,7 +48,7 @@ rule process (
     {
         case --help-internal :
         local path-to-modules = [ modules.peek : BOOST_BUILD_PATH ] ;
-        path-to-modules ?= . ;
+        path-to-modules += . ;
         local possible-modules = [ GLOB $(path-to-modules) : *\\.jam ] ;
         local not-modules = [ GLOB $(path-to-modules) : *$(.not-modules)\\.jam ] ;
         local modules-to-list =
@@ -177,7 +177,7 @@ local rule split-symbol (
     )
 {
     local path-to-modules = [ modules.peek : BOOST_BUILD_PATH ] ;
-    path-to-modules ?= . ;
+    path-to-modules += . ;
     local module-name = $(symbol) ;
     local symbol-name = ;
     local result = ;


### PR DESCRIPTION
This pull request adds support for help for modules in the current directory.  I added this because using `--help-internal` did not list the module and `--help module` with did not show the help.  I don't know if this is the best approach to adding this functionality, but adding new options would have required changing a lot of code in `help.jam` and `doc.jam`.  It was not simple to just add something there without duplicating some complicated code.

Both the `--help-internal` and `--help module` now search the current directory for modules.

I originally thought that adding the current directory to `BOOST_BUILD_PATH` would solve this problem, but it did not seem to.

I tried to poke the current directory into the `BOOST_BUILD_PATH` in each of `user-config.jam`, `project-config.jam`, and`site-config.jam`.  This works for importing the local module, but not when using `--help`.

```
{
  import modules ;

  local x = [ modules.peek : BOOST_BUILD_PATH ] ;
  modules.poke : BOOST_BUILD_PATH : . $(x) ;
}
```

I'm was sure this is the best way to approach this, so I have a few questions.

1. Is there a different way to do this?  Am I totally off base?

2. Should modifying `BOOST_BUILD_PATH` locally work?  If so, should I be doing that another way?

3. Should we add new options such as `--help-local` and`--help-internal-local` instead of modifying the search path of `--help` and `--help-internal`?

4. Should we rework the code of `help.jam` and `doc.jam` to be a bit more flexible?
