### PR TITLE
Set coverage flags for gcc and clang:

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -736,6 +736,9 @@ toolset.flags gcc.compile.c++ OPTIONS <thread-sanitizer>on : -fsanitize=thread ;
 toolset.flags gcc.compile.c++ OPTIONS <address-sanitizer>norecover : -fsanitize=address -fno-sanitize-recover=address ;
 toolset.flags gcc.compile.c++ OPTIONS <undefined-sanitizer>norecover : -fsanitize=undefined -fno-sanitize-recover=undefined ;
 toolset.flags gcc.compile.c++ OPTIONS <thread-sanitizer>norecover : -fsanitize=thread -fno-sanitize-recover=thread ;
+toolset.flags gcc.compile.c++ OPTIONS <coverage>all : --coverage ;
+toolset.flags gcc.compile.c++ OPTIONS <coverage>profile : -fprofile-arcs ;
+toolset.flags gcc.compile.c++ OPTIONS <coverage>test : -ftest-coverage ;
 
 # configure Dinkum STL to match compiler options
 toolset.flags gcc.compile.c++ DEFINES <rtti>off/<target-os>vxworks : _NO_RTTI ;
@@ -882,6 +885,9 @@ toolset.flags gcc.link OPTIONS <thread-sanitizer>on : -fsanitize=thread ;
 toolset.flags gcc.link OPTIONS <address-sanitizer>norecover : -fsanitize=address -fno-sanitize-recover=address ;
 toolset.flags gcc.link OPTIONS <undefined-sanitizer>norecover : -fsanitize=undefined -fno-sanitize-recover=undefined ;
 toolset.flags gcc.link OPTIONS <thread-sanitizer>norecover : -fsanitize=thread -fno-sanitize-recover=thread ;
+toolset.flags gcc.link OPTIONS <coverage>all : --coverage ;
+toolset.flags gcc.link OPTIONS <coverage>profile : -fprofile-arcs ;
+toolset.flags gcc.link OPTIONS <coverage>test : -lgcov ;
 
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>windows : "-Wl,--out-implib," ;
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib," ;


### PR DESCRIPTION
- `<coverage>all` sets up `--coverage` for compiler and linker
- `<coverage>profile` sets up `-fprofile-arcs` for compiler and linker
- `<coverage>test` sets up `-ftest-coverage` for compiler and
  `-lgcov` for linker

Reference:
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html