### PR TITLE
Add /manifest to clang-win.link

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -156,7 +156,7 @@ rule init ( version ? : command * : options * )
         if $(addr) = 32 { cond += "$(condition)/<architecture>/<address-model>" ; }
 
         toolset.flags clang-win.compile .CC $(cond) : $(compiler) -m$(addr) ;
-        toolset.flags clang-win.link .LD $(cond) : $(compiler) -m$(addr) /link "/incremental:no" ;
+        toolset.flags clang-win.link .LD $(cond) : $(compiler) -m$(addr) /link "/incremental:no" "/manifest" ;
         toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -nologo ;
         toolset.flags clang-win.archive .LD $(cond) : $(archiver) /nologo ;
         toolset.flags clang-win.link .MT $(cond) : $(manifest-tool) -nologo ;


### PR DESCRIPTION
Executables that contain "update" in their names, such as for instance `mp_map_update.exe` and `mp_map_update_q.exe` from the Mp11 test suite, automatically request elevation (at least on Windows 7.)

This doesn't happen for the msvc toolset, because it passes `/manifest` to the linker, which generates a manifest file, which then gets embedded into the executable and suppresses the installer autodetection.

The clang-win toolset, however, didn't pass `/manifest` to the linker, so no manifest was produced, and even though the `msvc.manifest` rule was invoked, it did nothing.