### PR TITLE
features: Add freertos as an operating system.

### DIFF
--- a/src/tools/features/os-feature.jam
+++ b/src/tools/features/os-feature.jam
@@ -12,6 +12,7 @@ import os ;
 .os-names =
     aix android appletv bsd cygwin darwin freebsd haiku hpux iphone linux
     netbsd openbsd osf qnx qnxnto sgi solaris unix unixware windows vms vxworks
+    freertos
     
     # Not actually an OS -- used for targeting bare metal where object
     # format is ELF.  This catches both -elf and -eabi gcc targets as well


### PR DESCRIPTION
This pull request adds FreeRTOS (`freetos`) to the list of operating systems, which has the result of adding it to the available operating systems in the `target-os` feature.

This is not (yet) used anywhere in Boost.Build and so is just useful for users of Boost.Build that might want to build something for FreeRTOS.  I'm not sure much could be done without providing a `freertos` module since FreeRTOS is pretty configurable and would be hard to generalize for a specific toolset such as `gcc`.  I may try to add a module for FreeRTOS sometime later.

I didn't see any tests for specific target operating systems (e.g. `elf` for bare-metal systems), so I didn't try to add any here.

I'm using this right now while developing a generator for the Xilinx SDK, which can generate a BSP for a bare-metal system or a FreeRTOS system for various processors.