### PR TITLE
Support values for instruction-set feature for Xilinx ZYNQ.

### DIFF
--- a/src/tools/features/instruction-set-feature.jam
+++ b/src/tools/features/instruction-set-feature.jam
@@ -42,6 +42,8 @@ feature.feature instruction-set
         # Advanced RISC Machines
         armv2 armv2a armv3 armv3m armv4 armv4t armv5 armv5t armv5te armv6 armv6j iwmmxt ep9312
         armv7 armv7s
+
+        cortex-a9+vfpv3 cortex-a53 cortex-r5 cortex-r5+vfpv3-d16
 	
 	# z Systems (aka s390x)
 	z196 zEC12 z13 z14

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -1308,5 +1308,10 @@ cpu-flags gcc OPTIONS : s390x : z196 : -march=z196 ;
 cpu-flags gcc OPTIONS : s390x : zEC12 : -march=zEC12 ;
 cpu-flags gcc OPTIONS : s390x : z13 : -march=z13 ;
 cpu-flags gcc OPTIONS : s390x : z14 : -march=z14 ;
+# ARM
+cpu-flags gcc OPTIONS : arm : cortex-a9+vfpv3 : -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard ;
+cpu-flags gcc OPTIONS : arm : cortex-a53 : -mcpu=cortex-a53 ;
+cpu-flags gcc OPTIONS : arm : cortex-r5 : -mcpu=cortex-r5 ;
+cpu-flags gcc OPTIONS : arm : cortex-r5+vfpv3-d16 : -mcpu=cortex-r5 -mfpu=vfpv3-d16 -mfloat-abi=hard ;
 # AIX variant of RS/6000 & PowerPC
 toolset.flags gcc AROPTIONS <address-model>64/<target-os>aix : "-X64" ;


### PR DESCRIPTION
Note that this description is a lot of words describing the change as well  as asking some larger questions about how we might want to support more processor tuning.  I welcome all feedback in specific and in general.

This pull request adds support for several very specific ARM instruction sets or processors (including extensions) to the `gcc` `toolset`.  These processors are used in various Xilinx ZYNQ FPGA systems.  The naming format used is one described in the GCC 8.3.0 manual (see Section 3.18.4) for lack of a more authoritative source.  GCC supports adding extensions such as FPU using a `+` syntax that seems pretty flexible.  It's basically `processor-name+extension-0+extension-1...`.  While the naming format is flexible, this pull request only adds four `instruction-set` configurations, which covers all existing Xilinx ZYNQ.

Some notes:

* only `gcc` is supported
* only four processors (with extensions) are supported: `cortex-r5`, `cortex-a53`, `cortex-a9+vfpv3`, `cortex-r5+vfpv3-d16`
* an unsupported `instruction-set` just gets no additional options for `gcc`
* a `toolset` that does not support an `instruction-set` 

The motivation for this change is to support these processors in a module to generate a BSP (and linker command file) using the Xilinx SDK.  This module is still in development.  If a processor is not supported in the toolset (e.g. `gcc`), then properties which normally propagate (e.g. `instruction-set`) do propagate so that the path reflects the `instruction-set`, the compiler options do not.  Note that the Xilinx SDK builds libraries and so defines what instruction set and extensions are required by programs that use those libraries.

If this change is too narrow since it doesn't cover all (or most) ARM instruction sets or processors, both with extensions, what else can I do?  I'd really like to be able to support all ARM architecture (plus extensions) or instruction-set (plus extensions), but that is a much bigger change.  The combinations of options is large and they should probably be generated.  Adding general support for ARM might require changing how `cpu-flags` are defined and / or used in `gcc`.  Any `toolset` that supports the ARM architecture should also have support for this as well, but I have not looked at other toolsets that support ARM and I don't necessarily have access to all those compilers.

Note that there are many more ARM processors and it would be really nice to support directly.  Unfortunately, versions of GCC prior to 8 do not support that format directly in the `-mcpu` option.  In order to support all these combinations, we would have to be able to use the `-mcpu` and `-mfpu` along with any other required options.  I don't think this would be a problem since GCC tends to be backwards compatible, but there is no guarantee every combination would be valid on any compiler or compiler version.
