### PR TITLE
simplified coverage options and added docs

### DIFF
--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -352,6 +352,11 @@ The `<warnings-as-errors>` makes it possible to treat warnings as
 errors and abort compilation on a warning. The value `on` enables this
 behavior. The default value is `off`.
 
+[[bbv2.builtin.features.coverage]]`coverage`::
+The `<coverage>` feature controls whether the code is instrumented to
+generate coverage data during execution.
+The value `on` enables this. The default value is `off`.
+
 [[bbv2.builtin.features.build]]`build`::
 *Allowed values:* `no`
 +

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -197,6 +197,11 @@ def register_globals ():
         'on'],        # Fail the compilation if there are warnings.
         ['incidental', 'propagated'])
 
+    feature.feature('coverage', [
+        'on',         # Enable coverage generation for the tool.
+        'off'],       # Disable coverage generation for the tool.
+        ['incidental', 'propagated'])
+
     feature.feature('c++-template-depth',
         [str(i) for i in range(64,1024+1,64)] +
         [str(i) for i in range(20,1000+1,10)] +

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -198,8 +198,8 @@ def register_globals ():
         ['incidental', 'propagated'])
 
     feature.feature('coverage', [
-        'on',         # Enable coverage generation for the tool.
-        'off'],       # Disable coverage generation for the tool.
+        'off',        # Disable coverage generation for the tool.
+        'on'],        # Enable coverage generation for the tool.
         ['incidental', 'propagated'])
 
     feature.feature('c++-template-depth',

--- a/src/tools/features/coverage-feature.jam
+++ b/src/tools/features/coverage-feature.jam
@@ -1,12 +1,13 @@
 # Copyright 2019 Rene Rivera
+# Copyright 2019 Hans Dembinski
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-# What kind of coverage information to generate.
-
 import feature ;
 
 feature.feature coverage
-    : off all test profile
-    : propagated optional ;
+    :
+    on          # Enable coverage generation for the tool.
+    off         # Disable coverage generation for the tool.
+    : incidental propagated ;

--- a/src/tools/features/coverage-feature.jam
+++ b/src/tools/features/coverage-feature.jam
@@ -8,6 +8,6 @@ import feature ;
 
 feature.feature coverage
     :
+    off         # Disable coverage generation for the tool (default).
     on          # Enable coverage generation for the tool.
-    off         # Disable coverage generation for the tool.
     : incidental propagated ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -738,9 +738,7 @@ toolset.flags gcc.compile.c++ OPTIONS <address-sanitizer>norecover : -fsanitize=
 toolset.flags gcc.compile.c++ OPTIONS <undefined-sanitizer>norecover : -fsanitize=undefined -fno-sanitize-recover=undefined ;
 toolset.flags gcc.compile.c++ OPTIONS <thread-sanitizer>norecover : -fsanitize=thread -fno-sanitize-recover=thread ;
 toolset.flags gcc.compile.c++ OPTIONS <leak-sanitizer>norecover : -fsanitize=leak -fno-sanitize-recover=leak ;
-toolset.flags gcc.compile.c++ OPTIONS <coverage>all : --coverage ;
-toolset.flags gcc.compile.c++ OPTIONS <coverage>profile : -fprofile-arcs ;
-toolset.flags gcc.compile.c++ OPTIONS <coverage>test : -ftest-coverage ;
+toolset.flags gcc.compile.c++ OPTIONS <coverage>on : --coverage ;
 
 # configure Dinkum STL to match compiler options
 toolset.flags gcc.compile.c++ DEFINES <rtti>off/<target-os>vxworks : _NO_RTTI ;
@@ -889,9 +887,7 @@ toolset.flags gcc.link OPTIONS <address-sanitizer>norecover : -fsanitize=address
 toolset.flags gcc.link OPTIONS <undefined-sanitizer>norecover : -fsanitize=undefined -fno-sanitize-recover=undefined ;
 toolset.flags gcc.link OPTIONS <thread-sanitizer>norecover : -fsanitize=thread -fno-sanitize-recover=thread ;
 toolset.flags gcc.link OPTIONS <leak-sanitizer>norecover : -fsanitize=leak -fno-sanitize-recover=leak ;
-toolset.flags gcc.link OPTIONS <coverage>all : --coverage ;
-toolset.flags gcc.link OPTIONS <coverage>profile : -fprofile-arcs ;
-toolset.flags gcc.link OPTIONS <coverage>test : -lgcov ;
+toolset.flags gcc.link OPTIONS <coverage>on : --coverage ;
 
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>windows : "-Wl,--out-implib," ;
 toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib," ;


### PR DESCRIPTION
Thank you for working on the coverage feature. I discovered the previous work by accident. This patch simplifies the options to just "on" and "off". `-fprofile-arcs` could be used alone, but there is no use case known to me for instrumenting the code but then not write the results somehwere. `-ftest-coverage` doesn't work without `-fprofile-arcs`. I argue the options should be kept simple, unless more fine-grained control is actually requested, and then more options can be added on top of "on" and "off".

This patch also adds documentation.