### PR TITLE
Fix compiler warnings about -std=gnu11 on Cygwin.

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -177,7 +177,7 @@ case $B2_TOOLSET in
         ;;
 
         *cygwin*)
-        B2_CXX="${CXX} -x c++ -std=gnu11"
+        B2_CXX="${CXX} -x c++ -std=gnu++11"
         B2_CXXFLAGS_RELEASE="-O2 -s"
         B2_CXXFLAGS_DEBUG="-O0 -g"
         ;;


### PR DESCRIPTION
-std=gnu11 is a flag for C source files, for C++ -std=gnu++11 should be used.