### PR TITLE
Extracts version of IBM and Sun compilers

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -241,7 +241,7 @@ case $B2_TOOLSET in
 
     vacpp)
         CXX=${CXX:=xlC_r}
-        CXX_VERSION_OPT=${CXX_VERSION_OPT:=--version}
+        CXX_VERSION_OPT=${CXX_VERSION_OPT:=-qversion}
         B2_CXX="${CXX}"
         B2_CXXFLAGS_RELEASE="-O3 -s -qstrict -qinline"
         B2_CXXFLAGS_DEBUG="-g -qNOOPTimize -qnoinline -pg"
@@ -249,7 +249,7 @@ case $B2_TOOLSET in
 
     xlcpp)
         CXX=${CXX:=xlC_r}
-        CXX_VERSION_OPT=${CXX_VERSION_OPT:=--version}
+        CXX_VERSION_OPT=${CXX_VERSION_OPT:=-qversion}
         B2_CXX="${CXX}"
         B2_CXXFLAGS_RELEASE="-s -O3 -qstrict -qinline"
         B2_CXXFLAGS_DEBUG="-g -qNOOPTimize -qnoinline -pg"
@@ -305,7 +305,7 @@ case $B2_TOOLSET in
 
     sun*)
         CXX=${CXX:=CC}
-        CXX_VERSION_OPT=${CXX_VERSION_OPT:=--version}
+        CXX_VERSION_OPT=${CXX_VERSION_OPT:=-V}
         if test -z "${B2_TOOLSET_ROOT}" -a -r /opt/SUNWspro/bin/CC ; then
             B2_TOOLSET_ROOT=/opt/SUNWspro/
         fi


### PR DESCRIPTION
xlc and suncc do not support the --version flag. This PR fixes the bootstrapper to use the correct flags.