### PR TITLE
Stick to C++98 features for now

### DIFF
--- a/src/engine/sysinfo.cpp
+++ b/src/engine/sysinfo.cpp
@@ -7,7 +7,9 @@
 #include "jam.h"
 #include "output.h"
 
+#if __cplusplus >= 201103L
 #include <thread>
+#endif
 
 #if defined(OS_MACOSX)
 #include <sys/types.h>
@@ -29,6 +31,7 @@
 
 
 b2::system_info::system_info()
+    : cpu_core_count_(0), cpu_thread_count_(0)
 {
 }
 
@@ -90,7 +93,11 @@ namespace
 
     unsigned int std_thread_hardware_concurrency()
     {
+        #if __cplusplus >= 201103L
         return std::thread::hardware_concurrency();
+        #else
+        return 0;
+        #endif
     }
 }
 

--- a/src/engine/sysinfo.h
+++ b/src/engine/sysinfo.h
@@ -38,8 +38,8 @@ namespace b2
 
         private:
 
-        unsigned int cpu_core_count_ = 0;
-        unsigned int cpu_thread_count_ = 0;
+        unsigned int cpu_core_count_;
+        unsigned int cpu_thread_count_;
     };
 }
 


### PR DESCRIPTION
Fixes #473, #534, #535. Tested with the "borland" toolchain, which still uses `bcc32.exe`.