### PR TITLE
add LTO support

### DIFF
--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -566,6 +566,8 @@ The `local-visibility` feature supports the same values with the same meaning
 as the `visibility` feature. By default, if `local-visibility` is not specified
 for a target, the value of the `visibility` feature is used.
 
+include::../../src/tools/features/lto-feature.jam[tag=doc]
+
 [[bbv2.reference.tools]]
 == Builtin tools
 

--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -16,9 +16,9 @@ import generators ;
 
 feature.extend-subfeature toolset clang : platform : darwin ;
 
-toolset.inherit-generators clang-darwin 
-  <toolset>clang <toolset-clang:platform>darwin 
-  : gcc 
+toolset.inherit-generators clang-darwin
+  <toolset>clang <toolset-clang:platform>darwin
+  : gcc
   # Don't inherit PCH generators. They were not tested, and probably
   # don't work for this compiler.
   : gcc.mingw.link gcc.mingw.link.dll gcc.compile.c.pch gcc.compile.c++.pch
@@ -32,30 +32,30 @@ generators.register-c-compiler clang-darwin.compile.m : OBJECTIVE_C : OBJ : <too
 generators.register-c-compiler clang-darwin.compile.mm : OBJECTIVE_CPP : OBJ : <toolset>clang <toolset-clang:platform>darwin ;
 
 toolset.inherit-rules clang-darwin : gcc ;
-toolset.inherit-flags clang-darwin : gcc 
+toolset.inherit-flags clang-darwin : gcc
         : <inlining>full
           <architecture>x86/<address-model>32
           <architecture>x86/<address-model>64
         ;
-        
+
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
 {
     .debug-configuration = true ;
 }
-                       
+
 # Initializes the clang-darwin toolset
 #   version in optional
 #   name (default clang++) is used to invoke the specified clang compiler
 #   compile and link options allow you to specify addition command line options for each version
 rule init ( version ? :  command * : options * )
 {
-    command = [ common.get-invocation-command clang-darwin : clang++ 
+    command = [ common.get-invocation-command clang-darwin : clang++
         : $(command) : /usr/bin /usr/local/bin ] ;
 
     # Determine the version
     local command-string = $(command:J=" ") ;
     if $(command)
-    {    
+    {
         version ?= [ MATCH "version ([0-9]+[.][0-9]+)"
             : [ SHELL "$(command-string) --version" ] ] ;
     }
@@ -90,6 +90,10 @@ toolset.flags clang-darwin.compile OPTIONS <inlining>full : -Wno-inline ;
 # shouldn't this be handled by the common gcc?
 toolset.flags clang-darwin.compile OPTIONS <flags> ;
 
+# LTO
+toolset.flags clang-darwin.compile OPTIONS <lto>on : -flto=thin ;
+toolset.flags clang-darwin.link OPTIONS <lto>on : -flto=thin ;
+
 actions compile.c
 {
     "$(CONFIG_COMMAND)" -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
@@ -123,11 +127,11 @@ rule archive ( targets * : sources * : properties * )
   # Always remove archive and start again. Here's rationale from
   # Andre Hentz:
   #
-  # I had a file, say a1.c, that was included into liba.a. 
-  # I moved a1.c to a2.c, updated my Jamfiles and rebuilt. 
-  # My program was crashing with absurd errors. 
-  # After some debugging I traced it back to the fact that a1.o was *still* 
-  # in liba.a 
+  # I had a file, say a1.c, that was included into liba.a.
+  # I moved a1.c to a2.c, updated my Jamfiles and rebuilt.
+  # My program was crashing with absurd errors.
+  # After some debugging I traced it back to the fact that a1.o was *still*
+  # in liba.a
   #
   # Rene Rivera:
   #

--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -36,6 +36,8 @@ toolset.inherit-flags clang-darwin : gcc
         : <inlining>full
           <architecture>x86/<address-model>32
           <architecture>x86/<address-model>64
+          <lto>on/<lto-mode>full
+          <lto>on/<lto-mode>fat
         ;
 
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
@@ -91,8 +93,11 @@ toolset.flags clang-darwin.compile OPTIONS <inlining>full : -Wno-inline ;
 toolset.flags clang-darwin.compile OPTIONS <flags> ;
 
 # LTO
-toolset.flags clang-darwin.compile OPTIONS <lto>on : -flto=thin ;
-toolset.flags clang-darwin.link OPTIONS <lto>on : -flto=thin ;
+toolset.flags clang-darwin.compile OPTIONS <lto>on/<lto-mode>thin : -flto=thin ;
+toolset.flags clang-darwin.link OPTIONS <lto>on/<lto-mode>thin : -flto=thin ;
+
+toolset.flags clang-darwin.compile OPTIONS <lto>on/<lto-mode>full : -flto=full ;
+toolset.flags clang-darwin.link OPTIONS <lto>on/<lto-mode>full : -flto=full ;
 
 actions compile.c
 {

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -20,7 +20,7 @@ import numbers ;
 
 feature.extend-subfeature toolset clang : platform : linux ;
 
-toolset.inherit-generators clang-linux 
+toolset.inherit-generators clang-linux
     <toolset>clang <toolset-clang:platform>linux : gcc
   : gcc.mingw.link gcc.mingw.link.dll gcc.cygwin.link gcc.cygwin.link.dll ;
 generators.override clang-linux.prebuilt : builtin.lib-generator ;
@@ -30,26 +30,26 @@ generators.override clang-linux.searched-lib-generator : searched-lib-generator 
 # Override default do-nothing generators.
 generators.override clang-linux.compile.c.pch   : pch.default-c-pch-generator   ;
 generators.override clang-linux.compile.c++.pch : pch.default-cpp-pch-generator ;
- 
+
 type.set-generated-target-suffix PCH
   : <toolset>clang <toolset-clang:platform>linux : pth ;
 
 toolset.inherit-rules clang-linux : gcc ;
-toolset.inherit-flags clang-linux : gcc 
+toolset.inherit-flags clang-linux : gcc
   : <inlining>full
     <threading>multi/<target-os>windows
   ;
-        
+
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ] {
   .debug-configuration = true ;
 }
-                       
+
 rule init ( version ? :  command * : options * ) {
-  command = [ common.get-invocation-command clang-linux : clang++ 
+  command = [ common.get-invocation-command clang-linux : clang++
     : $(command) ] ;
-                
+
   # Determine the version
-  if $(command) {    
+  if $(command) {
     local command-string = \"$(command)\" ;
     command-string = $(command-string:J=" ") ;
     version ?= [ MATCH "version ([0-9.]+)"
@@ -58,7 +58,7 @@ rule init ( version ? :  command * : options * ) {
 
   local condition = [ common.check-init-parameters clang-linux
     : version $(version) ] ;
-    
+
   common.handle-options clang-linux : $(condition) : $(command) : $(options) ;
   clang.init-cxxstd-flags clang-linux : $(condition) : $(version) ;
 
@@ -69,9 +69,9 @@ rule init ( version ? :  command * : options * ) {
   # can be found at runtime, while the $(command) can be a script that sets the
   # PATH for both the clang directory and the backende gcc directory
   # before calling clang++ when compiling/linking.
-  
+
   local root = [ feature.get-values <root> : $(options) ] ;
-    
+
   if $(root)
     {
         # On multilib 64-bit boxes, there are both 32-bit and 64-bit libraries
@@ -86,7 +86,7 @@ rule init ( version ? :  command * : options * ) {
         }
         toolset.flags clang-linux.link RUN_PATH $(condition) : $(lib_path) ;
     }
-    
+
   # - Ranlib.
   local ranlib = [ feature.get-values <ranlib> : $(options) ] ;
   if ( ! $(ranlib) ) && $(root)
@@ -113,6 +113,10 @@ toolset.flags clang-linux.compile OPTIONS <inlining>full : -Wno-inline ;
 
 toolset.flags clang-linux.compile OPTIONS <threading>multi/<target-os>windows : -pthread ;
 toolset.flags clang-linux.link OPTIONS <threading>multi/<target-os>windows : -pthread ;
+
+# LTO
+toolset.flags clang-linux.compile OPTIONS <lto>on : -flto=thin ;
+toolset.flags clang-linux.link OPTIONS <lto>on : -flto=thin ;
 
 ###############################################################################
 # C and C++ compilation

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -38,6 +38,8 @@ toolset.inherit-rules clang-linux : gcc ;
 toolset.inherit-flags clang-linux : gcc
   : <inlining>full
     <threading>multi/<target-os>windows
+    <lto>on/<lto-mode>full
+    <lto>on/<lto-mode>fat
   ;
 
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ] {
@@ -115,8 +117,11 @@ toolset.flags clang-linux.compile OPTIONS <threading>multi/<target-os>windows : 
 toolset.flags clang-linux.link OPTIONS <threading>multi/<target-os>windows : -pthread ;
 
 # LTO
-toolset.flags clang-linux.compile OPTIONS <lto>on : -flto=thin ;
-toolset.flags clang-linux.link OPTIONS <lto>on : -flto=thin ;
+toolset.flags clang-linux.compile OPTIONS <lto>on/<lto-mode>thin : -flto=thin ;
+toolset.flags clang-linux.link OPTIONS <lto>on/<lto-mode>thin : -flto=thin ;
+
+toolset.flags clang-linux.compile OPTIONS <lto>on/<lto-mode>full : -flto=full ;
+toolset.flags clang-linux.link OPTIONS <lto>on/<lto-mode>full : -flto=full ;
 
 ###############################################################################
 # C and C++ compilation

--- a/src/tools/features/lto-feature.jam
+++ b/src/tools/features/lto-feature.jam
@@ -15,7 +15,6 @@ and <<bbv2.reference.tools.compiler.msvc>>.
 +
 The `lto-mode` subfeature specifies the type of LTO to use.
 +
-`deafult`::: Use toolset default.
 `full`::: Use the monolithic LTO: on linking all input is merged into a single
   module.
 `thin`::: Use clang's ThinLTO: each compiled file contains a summary of the
@@ -35,5 +34,5 @@ feature.feature lto
 
 feature.subfeature lto
     : mode
-    : default full thin fat
+    : full thin fat
     : propagated ;

--- a/src/tools/features/lto-feature.jam
+++ b/src/tools/features/lto-feature.jam
@@ -1,0 +1,12 @@
+# Copyright 2019 Dmitry Arkhipov
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+# TODO: Documentation.
+
+import feature ;
+
+feature.feature lto
+    : off on
+    : propagated ;

--- a/src/tools/features/lto-feature.jam
+++ b/src/tools/features/lto-feature.jam
@@ -3,7 +3,17 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-# TODO: Documentation.
+#| tag::doc[]
+
+[[bbv2.builtin.features.lto]]`lto`::
+*Allowed values:* `off`, `on`.
++
+This feature enables link time optimizations (also known as interprocedural
+optimizations or whole-program optimizations). Currently supported toolsets
+are <<bbv2.reference.tools.compiler.gcc>>, clang
+and <<bbv2.reference.tools.compiler.msvc>>.
+
+|# # end::doc[]
 
 import feature ;
 

--- a/src/tools/features/lto-feature.jam
+++ b/src/tools/features/lto-feature.jam
@@ -12,6 +12,18 @@ This feature enables link time optimizations (also known as interprocedural
 optimizations or whole-program optimizations). Currently supported toolsets
 are <<bbv2.reference.tools.compiler.gcc>>, clang
 and <<bbv2.reference.tools.compiler.msvc>>.
++
+The `lto-mode` subfeature specifies the type of LTO to use.
++
+`deafult`::: Use toolset default.
+`full`::: Use the monolithic LTO: on linking all input is merged into a single
+  module.
+`thin`::: Use clang's ThinLTO: each compiled file contains a summary of the
+  module, these summaries are merged into a single index. This allows to avoid
+  merging all modules together, which greatly reduces linking time.
+`fat`::: Produce gcc's fat LTO objects: compiled files contain both the
+  intermidiate language suitable for LTO and object code suitable for regular
+  linking.
 
 |# # end::doc[]
 
@@ -19,4 +31,9 @@ import feature ;
 
 feature.feature lto
     : off on
+    : propagated ;
+
+feature.subfeature lto
+    : mode
+    : default full thin fat
     : propagated ;

--- a/src/tools/features/lto-feature.jam
+++ b/src/tools/features/lto-feature.jam
@@ -3,17 +3,31 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+import feature ;
+
 #| tag::doc[]
 
 [[bbv2.builtin.features.lto]]`lto`::
-*Allowed values:* `off`, `on`.
+*Allowed values:* `on`.
 +
-This feature enables link time optimizations (also known as interprocedural
-optimizations or whole-program optimizations). Currently supported toolsets
-are <<bbv2.reference.tools.compiler.gcc>>, clang
-and <<bbv2.reference.tools.compiler.msvc>>.
+Enables link time optimizations (also known as interprocedural optimizations or
+whole-program optimizations). Currently supported toolsets are <<GNU {CPP}>>,
+clang and <<Microsoft Visual {CPP}>>. The feature is optional.
+
+|# # end::doc[]
+
+feature.feature lto
+    : on
+    : optional propagated ;
+
+#| tag::doc[]
+
+[[bbv2.builtin.features.lto-mode]]`lto-mode`::
+*Subfeature of* `lto`
 +
-The `lto-mode` subfeature specifies the type of LTO to use.
+*Allowed values:* `full`, `thin`, `fat`.
++
+Specifies the type of LTO to use.
 +
 `full`::: Use the monolithic LTO: on linking all input is merged into a single
   module.
@@ -25,12 +39,6 @@ The `lto-mode` subfeature specifies the type of LTO to use.
   linking.
 
 |# # end::doc[]
-
-import feature ;
-
-feature.feature lto
-    : off on
-    : propagated ;
 
 feature.subfeature lto
     : mode

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -749,8 +749,14 @@ toolset.flags gcc.compile.c++ DEFINES <rtti>off/<target-os>vxworks : _NO_RTTI ;
 toolset.flags gcc.compile.c++ DEFINES <exception-handling>off/<target-os>vxworks : _NO_EX=1 ;
 
 # LTO
-toolset.flags gcc.compile OPTIONS <lto>on : -flto ;
-toolset.flags gcc.link OPTIONS <lto>on : -flto ;
+toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>default : -flto ;
+toolset.flags gcc.link OPTIONS <lto>on/<lto-mode>default : -flto ;
+
+toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>full : -flto -ffat-lto-objects ;
+toolset.flags gcc.link OPTIONS <lto>on/<lto-mode>full : -flto ;
+
+toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>fat : -flto -ffat-lto-objects ;
+toolset.flags gcc.link OPTIONS <lto>on/<lto-mode>fat : -flto ;
 
 
 ###

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -748,6 +748,11 @@ toolset.flags gcc.compile.c++ OPTIONS <coverage>on : --coverage ;
 toolset.flags gcc.compile.c++ DEFINES <rtti>off/<target-os>vxworks : _NO_RTTI ;
 toolset.flags gcc.compile.c++ DEFINES <exception-handling>off/<target-os>vxworks : _NO_EX=1 ;
 
+# LTO
+toolset.flags gcc.compile OPTIONS <lto>on : -flto ;
+toolset.flags gcc.link OPTIONS <lto>on : -flto ;
+
+
 ###
 ### User free feature options.
 ###

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -749,10 +749,7 @@ toolset.flags gcc.compile.c++ DEFINES <rtti>off/<target-os>vxworks : _NO_RTTI ;
 toolset.flags gcc.compile.c++ DEFINES <exception-handling>off/<target-os>vxworks : _NO_EX=1 ;
 
 # LTO
-toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>default : -flto ;
-toolset.flags gcc.link OPTIONS <lto>on/<lto-mode>default : -flto ;
-
-toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>full : -flto -ffat-lto-objects ;
+toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>full : -flto ;
 toolset.flags gcc.link OPTIONS <lto>on/<lto-mode>full : -flto ;
 
 toolset.flags gcc.compile OPTIONS <lto>on/<lto-mode>fat : -flto -ffat-lto-objects ;

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -480,9 +480,9 @@ rule configure-version-specific ( toolset : version : conditions )
 
 # Feature for handling targeting different Windows API sets.
 feature.feature windows-api : desktop store phone : propagated composite link-incompatible ;
-feature.compose <windows-api>store : <define>WINAPI_FAMILY=WINAPI_FAMILY_APP <define>_WIN32_WINNT=0x0602 
+feature.compose <windows-api>store : <define>WINAPI_FAMILY=WINAPI_FAMILY_APP <define>_WIN32_WINNT=0x0602
     <linkflags>/APPCONTAINER ;
-feature.compose <windows-api>phone : <define>WINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP <define>_WIN32_WINNT=0x0602 
+feature.compose <windows-api>phone : <define>WINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP <define>_WIN32_WINNT=0x0602
     <linkflags>/APPCONTAINER <linkflags>"/NODEFAULTLIB:ole32.lib" <linkflags>"/NODEFAULTLIB:kernel32.lib" <linkflags>WindowsPhoneCore.lib ;
 feature.set-default windows-api : desktop ;
 
@@ -729,7 +729,7 @@ rule link ( targets + : sources * : properties * )
             DEPENDS $(<) : [ on $(<) return $(EMBED_MANIFEST_FILE) ] ;
             msvc.manifest.user $(targets) $(EMBED_MANIFEST_FILE) : $(sources) : $(properties) ;
         }
-        else 
+        else
         {
             msvc.manifest $(targets) : $(sources) : $(properties) ;
         }
@@ -763,7 +763,7 @@ rule link.dll ( targets + : sources * : properties * )
             DEPENDS $(<) : [ on $(<) return $(EMBED_MANIFEST_FILE) ] ;
             msvc.manifest.dll.user $(targets) $(EMBED_MANIFEST_FILE) : $(sources) : $(properties) ;
         }
-        else 
+        else
         {
             msvc.manifest.dll $(targets) : $(sources) : $(properties) ;
         }
@@ -1003,13 +1003,13 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
 {
     local setup-options ;
     local setup = [ feature.get-values <setup-$(cpu)> : $(options) ] ;
-    
+
     if ! $(setup)-is-defined
     {
         if $(global-setup)-is-defined
         {
             setup = $(global-setup) ;
-                        
+
             # If needed we can easily add using configuration flags
             # here for overriding which options get passed to the
             # global setup command for which target platform:
@@ -1038,7 +1038,7 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
             setup ?= [ path.join  $(parent) "vcvarsall.bat" ] ;
         }
     }
-    
+
     return $(setup) "$(setup-options:J= )" ;
 }
 
@@ -1081,7 +1081,7 @@ IMPORT msvc : rewrite-setup : : msvc.rewrite-setup ;
 
 # Helper rule to generate a faster alternative to MSVC setup scripts.
 # We used to call MSVC setup scripts directly in every action, however in
-# newer MSVC versions (10.0+) they make long-lasting registry queries 
+# newer MSVC versions (10.0+) they make long-lasting registry queries
 # which have a significant impact on build time.
 local rule set-setup-command ( targets * : properties * )
 {
@@ -1282,7 +1282,7 @@ local rule configure-really ( version ? : options * )
 
         local below-8.0 = [ MATCH "^([67]\\.)" : $(version) ] ;
         local below-11.0 = [ MATCH "^([6789]\\.|10\\.)" : $(version) ] ;
-        
+
         local cpu = i386 amd64 ia64 arm arm64 ;
         if $(below-8.0)
         {
@@ -1292,7 +1292,7 @@ local rule configure-really ( version ? : options * )
         {
             cpu = i386 amd64 ia64 ;
         }
-        
+
         local setup-amd64 ;
         local setup-i386 ;
         local setup-ia64 ;
@@ -1403,7 +1403,7 @@ local rule configure-really ( version ? : options * )
                 exact-version ?= $(version) ;
                 setup-$(c) = [ generate-setup-cmd $(exact-version) : $(command) : $(parent) : $(options) : $(c) : $(global-setup) : $(default-global-setup-options-$(c)) : $(default-setup-$(c)) ] ;
             }
-            
+
             # Windows phone has different setup scripts, located in a different directory hierarchy.
             # The 11.0 toolset can target Windows Phone 8.0 and the 12.0 toolset can target Windows Phone 8.1,
             # each of which have a different directory for their vcvars setup scripts.
@@ -1418,7 +1418,7 @@ local rule configure-really ( version ? : options * )
                 phone-directory = [ path.native [ path.join $(phone-directory) WP81 ] ] ;
             }
             global-setup-phone ?= [ locate-default-setup $(phone-directory) : $(phone-parent) : vcvarsphoneall.bat ] ;
-                
+
             # If can't locate default phone setup script then this VS version doesn't support Windows Phone.
             if $(global-setup-phone)-is-defined
             {
@@ -1492,7 +1492,7 @@ local rule configure-really ( version ? : options * )
 
                 if <rewrite-setup-scripts>always in $(options)
                 {
-                    toolset.flags msvc .REWRITE-SETUP <windows-api>$(api)/$(cpu-conditions) : true ; 
+                    toolset.flags msvc .REWRITE-SETUP <windows-api>$(api)/$(cpu-conditions) : true ;
                 }
 
                 if ! $(setup-script)
@@ -1542,6 +1542,10 @@ local rule configure-really ( version ? : options * )
             toolset.flags msvc.link LINKPATH $(conditions)/<windows-api>store/$(.cpu-arch-amd64) : [ path.native [ path.join $(storeLibPath) "amd64" ] ] ;
             toolset.flags msvc.link LINKPATH $(conditions)/<windows-api>store/$(.cpu-arch-arm) : [ path.native [ path.join $(storeLibPath) "arm" ] ] ;
         }
+
+        # LTO
+        toolset.flags msvc.compile OPTIONS $(conditions)/<lto>on : /GL ;
+        toolset.flags msvc.link OPTIONS $(conditions)/<lto>on : /LTCG ;
 
         # Set version-specific flags.
         configure-version-specific msvc : $(version) : $(conditions) ;
@@ -1863,7 +1867,7 @@ local rule register-toolset-really ( )
         toolset.flags msvc.link FINDLIBS_SA <find-shared-library> ;
         toolset.flags msvc.link LIBRARY_OPTION <toolset>msvc : "" : unchecked ;
         toolset.flags msvc.link LIBRARIES_MENTIONED_BY_FILE : <library-file> ;
-        
+
         toolset.flags msvc.link.dll LINKFLAGS <suppress-import-lib>true : /NOENTRY ;
     }
 


### PR DESCRIPTION
Adds lto feature with 2 values: off (the default) and on. The feature
enables link-time optimizations. Also adds support for the feature to
gcc, clang and msvc toolsets.