### PR TITLE
#ifdef MINGW ...

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -86,7 +86,7 @@
 #define OS_NT
 #define SPLITPATH ';'
 #define MAXLINE 996  /* max chars per command line */
-#define USE_EXECUNIX
+#define USE_EXECNT
 #define PATH_DELIM '\\'
 
 #else

--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -110,10 +110,10 @@
 
 
 /*
- * Windows MingW32
+ * Windows MingW32 or Mingw64
  */
 
-#ifdef MINGW
+#if defined(__MINGW64__) || defined(__MINGW32__)
 
 #include <fcntl.h>
 #include <stdlib.h>
@@ -133,7 +133,7 @@
 #define USE_EXECUNIX
 #define PATH_DELIM '\\'
 
-#endif  /* #ifdef MINGW */
+#endif  /* #if defined(__MINGW64__) || defined(__MINGW32__) */
 
 
 /*

--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -64,6 +64,33 @@
 
 #endif
 
+
+/*
+ * Windows MingW32 or Mingw64
+ */
+
+#if defined(__MINGW64__) || defined(__MINGW32__)
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <malloc.h>
+#include <memory.h>
+#include <signal.h>
+#include <string.h>
+#include <time.h>
+
+#define OSMAJOR "MINGW=true"
+#define OSMINOR "OS=MINGW"
+#define OS_NT
+#define SPLITPATH ';'
+#define MAXLINE 996  /* max chars per command line */
+#define USE_EXECUNIX
+#define PATH_DELIM '\\'
+
+#else
+
 /*
  * Windows NT
  */
@@ -107,33 +134,9 @@
 #endif
 
 #endif  /* #ifdef NT */
-
-
-/*
- * Windows MingW32 or Mingw64
- */
-
-#if defined(__MINGW64__) || defined(__MINGW32__)
-
-#include <fcntl.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <malloc.h>
-#include <memory.h>
-#include <signal.h>
-#include <string.h>
-#include <time.h>
-
-#define OSMAJOR "MINGW=true"
-#define OSMINOR "OS=MINGW"
-#define OS_NT
-#define SPLITPATH ';'
-#define MAXLINE 996  /* max chars per command line */
-#define USE_EXECUNIX
-#define PATH_DELIM '\\'
-
 #endif  /* #if defined(__MINGW64__) || defined(__MINGW32__) */
+
+
 
 
 /*


### PR DESCRIPTION
Replaced with "#if defined(__MINGW64__) || defined(__MINGW32__)" to enable both MinGW and MinGW-w64 compilers.