### PR TITLE
Add proper armasm[64] support for MSVC toolchain

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -6,6 +6,7 @@
 # Copyright (c) 2007-2017 Rene Rivera
 # Copyright (c) 2008 Jurko Gospodnetic
 # Copyright (c) 2014 Microsoft Corporation
+# Copyright (c) 2019 Michał Janiszewski
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
@@ -561,15 +562,9 @@ rule compile.asm ( targets + : sources * : properties * )
     set-setup-command $(targets) : $(properties) ;
 }
 
-# For the assembler the following options are turned on by default:
-#
-#   -Zp4   align structures to 4 bytes
-#   -Cp    preserve case of user identifiers
-#   -Cx    preserve case in publics, externs
-#
 actions compile.asm
 {
-    $(.SETUP) $(.ASM) -c -Zp4 -Cp -Cx -D$(DEFINES) $(ASMFLAGS) $(USER_ASMFLAGS) -Fo "$(<:W)" "$(>:W)"
+    $(.SETUP) $(.ASM) -D$(ASMDEFINES) $(ASMFLAGS) $(USER_ASMFLAGS) $(.ASM_OUTPUT) "$(<:W)" "$(>:W)"
 }
 
 
@@ -1473,8 +1468,26 @@ local rule configure-really ( version ? : options * )
         local default-assembler-amd64 = ml64 ;
         local default-assembler-i386  = "ml -coff" ;
         local default-assembler-ia64  = ias ;
-        local default-assembler-ia64  = armasm ;
+        local default-assembler-arm   = armasm ;
         local default-assembler-arm64 = armasm64 ;
+
+        # For the assembler the following options are turned on by default:
+        #
+        #   -Zp4   align structures to 4 bytes
+        #   -Cp    preserve case of user identifiers
+        #   -Cx    preserve case in publics, externs
+        #
+        local assembler-flags-amd64 = "-c -Zp4 -Cp -Cx" ;
+        local assembler-flags-i386  = "-c -Zp4 -Cp -Cx" ;
+        local assembler-flags-ia64  = "-c -Zp4 -Cp -Cx" ;
+        local assembler-flags-arm   = "" ;
+        local assembler-flags-arm64 = "" ;
+
+        local assembler-output-flag-amd64 = -Fo ;
+        local assembler-output-flag-i386  = -Fo ;
+        local assembler-output-flag-ia64  = -Fo ;
+        local assembler-output-flag-arm   = -o ;
+        local assembler-output-flag-arm64 = -o ;
 
         assembler = [ feature.get-values <assembler> : $(options) ] ;
 
@@ -1507,6 +1520,8 @@ local rule configure-really ( version ? : options * )
 
             local cpu-assembler = $(assembler) ;
             cpu-assembler ?= $(default-assembler-$(c)) ;
+            local assembler-flags = $(assembler-flags-$(c)) ;
+            local assembler-output-flag = $(assembler-output-flag-$(c)) ;
 
             for local api in desktop store phone
             {
@@ -1548,7 +1563,8 @@ local rule configure-really ( version ? : options * )
                 {
                     toolset.flags msvc.compile .CC  <windows-api>$(api)/$(cpu-conditions) : $(compiler) /Zm800 /ZW /EHsc -nologo ;
                 }
-                toolset.flags msvc.compile .ASM <windows-api>$(api)/$(cpu-conditions) : $(cpu-assembler) -nologo ;
+                toolset.flags msvc.compile .ASM <windows-api>$(api)/$(cpu-conditions) : $(cpu-assembler) $(assembler-flags) -nologo ;
+                toolset.flags msvc.compile .ASM_OUTPUT <windows-api>$(api)/$(cpu-conditions) : $(assembler-output-flag) ;
                 toolset.flags msvc.link    .LD  <windows-api>$(api)/$(cpu-conditions) : $(linker) /NOLOGO "/INCREMENTAL:NO" ;
                 toolset.flags msvc.archive .LD  <windows-api>$(api)/$(cpu-conditions) : $(linker) /lib /NOLOGO  ;
             }
@@ -1861,14 +1877,14 @@ local rule register-toolset-really ( )
     # Declare flags for the assembler.
     toolset.flags msvc.compile.asm USER_ASMFLAGS <asmflags> ;
 
-    toolset.flags msvc.compile.asm ASMFLAGS <debug-symbols>on : "/Zi /Zd" ;
+    toolset.flags msvc.compile.asm ASMFLAGS <architecture>x86/<debug-symbols>on : "/Zi /Zd" ;
 
-    toolset.flags msvc.compile.asm ASMFLAGS <warnings>on : /W3 ;
-    toolset.flags msvc.compile.asm ASMFLAGS <warnings>off : /W0 ;
-    toolset.flags msvc.compile.asm ASMFLAGS <warnings>all : /W4 ;
-    toolset.flags msvc.compile.asm ASMFLAGS <warnings-as-errors>on : /WX ;
+    toolset.flags msvc.compile.asm ASMFLAGS <architecture>x86/<warnings>on : /W3 ;
+    toolset.flags msvc.compile.asm ASMFLAGS <architecture>x86/<warnings>off : /W0 ;
+    toolset.flags msvc.compile.asm ASMFLAGS <architecture>x86/<warnings>all : /W4 ;
+    toolset.flags msvc.compile.asm ASMFLAGS <architecture>x86/<warnings-as-errors>on : /WX ;
 
-    toolset.flags msvc.compile.asm DEFINES <define> ;
+    toolset.flags msvc.compile.asm ASMDEFINES <architecture>x86 : <define> ;
 
     # Declare flags for linking.
     {


### PR DESCRIPTION
armasm and armasm64, the MSVC toolchain's assemblers for arm and arm64
respectively, have completely different invocations than their ml and
ml64 counterparts targetting x86 and x86-64.

Here's the full output of armasm's help:
```
cmd> armasm64 -h
Microsoft (R) ARM Macro Assembler Version 14.23.28106.4 for 64 bits
Copyright (C) Microsoft Corporation.  All rights reserved.

 Usage:      armasm [<options>] sourcefile objectfile
             armasm [<options>] -o objectfile sourcefile
             armasm -h              for help

<options>:            (Upper case shows allowable abbreviation)
  -Errors     errorsfile       redirect stderr diagnostics to errorsfile
  -I          dir[;dir]        add dirs to include search path
  -PreDefine  directive        pre-execute a SET{L,A,S} directive
  -NOWarn                      turn off warning messages
  -ignore <warning-num>        don't report warning-num
  -Help                        help (this information)
  -via <file>                  read further arguments from <file>
  -machine <machine>           set the PE machine type field
  -g                           generate debugging info
  -gh:SHA_256                  use SHA256 for file checksum in debug info (experimental)
  -errorReport:<option>        report internal assembler errors to Microsoft
      none - do not send report
      prompt - prompt to immediately send report
      queue - at next admin logon, prompt to send report (default)
      send - send report automatically

<machine>:  ARM64
```

This patch is incomplete, as I struggle to work with JAM and would like to request some help. I have verified this was sufficient to ~~compile~~ assemble an object file with b2 targetting arm64 with this patch.

Things to address:
- [x] This updated definition needs to be only enabled for arm/arm64.
  - I tried making the action depend on `<architecture>` but couldn't find the proper way to express the condition.
  - I'm not sure if it is the best approach, the only other such top-level conditions check for `os.name`
  - I haven't seen conditional `generator.override`s either
- [x] The `<ASMFLAGS>` in https://github.com/boostorg/build/blob/e04b0c206e5d09e25262bed914e30324facdf9cb/src/tools/msvc.jam#L1864 may need only setting for x86-like targets, rather than outright removing them