### PR TITLE
Remove trailing apostrophe from version notice in msvc.jam

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1043,7 +1043,7 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
             {
                 if $(.debug-configuration)
                 {
-                    ECHO 'notice\: "[generate-setup-cmd]" $(version) is 14.2' ;
+                    ECHO "notice: [generate-setup-cmd] $(version) is 14.2" ;
                 }
                 parent = [ path.native [ path.join  $(parent) "..\\..\\..\\..\\..\\Auxiliary\\Build" ] ] ;
             }
@@ -1051,7 +1051,7 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
             {
                 if $(.debug-configuration)
                 {
-                    ECHO 'notice\: "[generate-setup-cmd]" $(version) is 14.1' ;
+                    ECHO "notice: [generate-setup-cmd] $(version) is 14.1" ;
                 }
                 parent = [ path.native [ path.join  $(parent) "..\\..\\..\\..\\..\\Auxiliary\\Build" ] ] ;
             }


### PR DESCRIPTION
Fixes formatting of these notices

```
notice: will use 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.24.28314\bin\Hostx64\x64\cl.exe' for msvc, condition <toolset>msvc-14.2
'notice: [generate-setup-cmd] 14.24.28314 is 14.2'
'notice: [generate-setup-cmd] 14.24.28314 is 14.2'
'notice: [generate-setup-cmd] 14.24.28314 is 14.2'
'notice: [generate-setup-cmd] 14.24.28314 is 14.2'
'notice: [generate-setup-cmd] 14.24.28314 is 14.2'
notice: [msvc-cfg] condition: '<toolset>msvc-14.2/<architecture>/<address-model>', setup: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars32.bat'
```