### PR TITLE
Add png16 and libpng16 to library names in libpng.jam

### DIFF
--- a/src/tools/libpng.jam
+++ b/src/tools/libpng.jam
@@ -24,6 +24,10 @@ import property ;
 import property-set ;
 
 header = png.h ;
+
+# On Windows, binary distributions of libpng and package managers
+# name the library differently (e.g. vcpkg installs libpng16.lib).
+# Listing popular names increases chances of successful look-up.
 names = libpng libpng16 png png16 ;
 
 sources =   png.c pngerror.c pngget.c pngmem.c pngpread.c pngread.c pngrio.c pngrtran.c pngrutil.c

--- a/src/tools/libpng.jam
+++ b/src/tools/libpng.jam
@@ -16,7 +16,7 @@ import ac ;
 import errors ;
 import feature ;
 import "class" : new ;
-import targets ; 
+import targets ;
 import path ;
 import modules ;
 import indirect ;
@@ -24,7 +24,7 @@ import property ;
 import property-set ;
 
 header = png.h ;
-names = png ;
+names = libpng libpng16 png png16 ;
 
 sources =   png.c pngerror.c pngget.c pngmem.c pngpread.c pngread.c pngrio.c pngrtran.c pngrutil.c
             pngset.c pngtrans.c pngwio.c pngwrite.c pngwtran.c pngwutil.c ;


### PR DESCRIPTION
On Windows, this allows to successfully find the library installed using vcpkg which deploys the library named as `libpng16.lib` and not `png16.lib` or `png.lib`.