### PR TITLE
define OSPLAT: MIPS64/MIPS32 instead of MIPS

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -412,7 +412,11 @@
 #endif
 
 #ifdef __mips__
-    #define OSPLAT "OSPLAT=MIPS"
+  #if defined(_ABI64)
+    #define OSPLAT "OSPLAT=MIPS64"
+  #elif defined(_ABIO32)
+    #define OSPLAT "OSPLAT=MIPS32"
+  #endif
 #endif
 
 #if defined( __arm__ ) || \


### PR DESCRIPTION
context need to define abi as o32 for MIPS32, while n64 for MIPS64.
we need a way to know about it.