### PR TITLE
add saxonhe_dir action

### DIFF
--- a/src/tools/saxonhe.jam
+++ b/src/tools/saxonhe.jam
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+# Copyright (c) 2019 Richard Hodges (hodges dot r at gmail dot com)
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -21,7 +22,20 @@ rule init ( saxonhe_jar ? : java_exe ? )
     }
 }
 
+#
+# execute the saxonhe jar file passing files as inputs and outputs.
+#
 actions saxonhe
 {
+    "$(.java_exe)" -jar "$(.saxonhe_jar)" -o:"$(<)" -s:"$(>[1])" -xsl:"$(>[2])"
+}
+
+#
+# execute the saxonhe jar file passing directories as inputs and outputs.
+# saxonhe requires that the output directory already exists
+#
+actions saxonhe_dir
+{
+    mkdir -p "$(<)"
     "$(.java_exe)" -jar "$(.saxonhe_jar)" -o:"$(<)" -s:"$(>[1])" -xsl:"$(>[2])"
 }


### PR DESCRIPTION
Latest boost beast documentation runs saxonhr against input and output directories.

This PR adds a new action that ensures that the output directory exists prior to executing the saxonhr jar file.
