### PR TITLE
bugfix: saxonhe_dir actions now conditional on build host OS

### DIFF
--- a/src/tools/saxonhe.jam
+++ b/src/tools/saxonhe.jam
@@ -7,6 +7,7 @@
 #
 
 import common ;
+import os ;
 
 rule init ( saxonhe_jar ? : java_exe ? )
 {
@@ -34,8 +35,19 @@ actions saxonhe
 # execute the saxonhe jar file passing directories as inputs and outputs.
 # saxonhe requires that the output directory already exists
 #
-actions saxonhe_dir
+if [ os.on-windows ]
 {
-    mkdir -p "$(<)"
-    "$(.java_exe)" -jar "$(.saxonhe_jar)" -o:"$(<)" -s:"$(>[1])" -xsl:"$(>[2])"
+    actions saxonhe_dir
+    {
+        if not exist "$(<)\\" mkdir "$(<)"
+        "$(.java_exe)" -jar "$(.saxonhe_jar)" -o:"$(<)" -s:"$(>[1])" -xsl:"$(>[2])"
+    }
+}
+else
+{
+    actions saxonhe_dir
+    {
+        mkdir -p "$(<)"
+        "$(.java_exe)" -jar "$(.saxonhe_jar)" -o:"$(<)" -s:"$(>[1])" -xsl:"$(>[2])"
+    }
 }


### PR DESCRIPTION
When I write the saxionhe_dir actions clause I did not realise that these actions are copied to the command line without interpretation with respect to the build host OS.

As a result, I fixed beast documentation building for linux, but broke it for windows.

This change fixes it for both.
