### PR TITLE
Fix MinGW version tag to match GCC

### DIFF
--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -974,7 +974,7 @@ local rule toolset-tag ( name : type ? : property-set )
     }
 
     # From GCC 5, versioning changes and minor becomes patch
-    if $(tag) = gcc && $(version[1]) && [ numbers.less 4 $(version[1]) ]
+    if ( $(tag) = gcc || $(tag) = mgw ) && $(version[1]) && [ numbers.less 4 $(version[1]) ]
     {
         version = $(version[1]) ;
     }


### PR DESCRIPTION
Reported in https://github.com/boostorg/boost_install/issues/26.