### PR TITLE
Add -std=c++11 flag because sysinfo uses c++11 features

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -314,7 +314,7 @@ case $B2_TOOLSET in
             export PATH
         fi
         B2_CXX="${CXX}"
-        B2_CXXFLAGS_RELEASE="-xO4 -s"
+        B2_CXXFLAGS_RELEASE="-xO4 -s -std=c++11"
         B2_CXXFLAGS_DEBUG="-g"
     ;;
 

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -313,8 +313,8 @@ case $B2_TOOLSET in
             PATH=${B2_TOOLSET_ROOT}bin:${PATH}
             export PATH
         fi
-        B2_CXX="${CXX}"
-        B2_CXXFLAGS_RELEASE="-xO4 -s -std=c++11"
+        B2_CXX="${CXX} -std=c++11"
+        B2_CXXFLAGS_RELEASE="-xO4 -s"
         B2_CXXFLAGS_DEBUG="-g"
     ;;
 


### PR DESCRIPTION
Fixes #530 

src/engine/build.sh
Added -std=c++11 flag to compile flags