### PR TITLE
move abstract-file-target.root to virtual-target

### DIFF
--- a/src/build/virtual-target.jam
+++ b/src/build/virtual-target.jam
@@ -174,6 +174,19 @@ class virtual-target
 
 # private: (overridables)
 
+    # Sets/gets the 'root' flag. Target is root if it directly corresponds to
+    # some variant of a main target.
+    #
+    rule root ( set ? )
+    {
+        if $(set)
+        {
+            self.root = true ;
+        }
+        return $(self.root) ;
+    }
+
+
     # Sets up build actions for 'target'. Should call appropriate rules and set
     # target variables.
     #
@@ -294,18 +307,6 @@ class abstract-file-target : virtual-target
     rule action ( )
     {
         return $(self.action) ;
-    }
-
-    # Sets/gets the 'root' flag. Target is root if it directly corresponds to
-    # some variant of a main target.
-    #
-    rule root ( set ? )
-    {
-        if $(set)
-        {
-            self.root = true ;
-        }
-        return $(self.root) ;
     }
 
     # Gets or sets the subvariant which created this target. Subvariant is set


### PR DESCRIPTION
seems to only be called from basic-target.create-subvariant, which
seems (looking at the comments and 5.6.4 of docs) to assume that it
exists on virtual-target.

without this fix a user wanting to produce something derived from
virtual-target in the construct-function of something derived from
basic-target will get an error.