### PR TITLE
Fix non-zero exit code on Jam parsing errors

### DIFF
--- a/src/engine/jam.cpp
+++ b/src/engine/jam.cpp
@@ -275,6 +275,7 @@ int main( int argc, char * * argv, char * * arg_environ )
     b2::system_info sys_info;
 
     saved_argv0 = argv[ 0 ];
+    last_update_now_status = 0;
 
     BJAM_MEM_INIT();
 
@@ -650,6 +651,8 @@ int main( int argc, char * * argv, char * * arg_environ )
         }
 
         status = yyanyerrors();
+        if ( status && !last_update_now_status )
+            last_update_now_status = status;
 
         /* Manually touch -t targets. */
         for ( n = 0; ( s = getoptval( optv, 't', n ) ); ++n )


### PR DESCRIPTION
Prevent resetting the non-Zero status returned from yyanyerrors on any parsing errors.

-----

The bug was reported on #boost Slack

------

A basic verification of the fix:

1. `Jamfile` with a broken syntax

![image](https://user-images.githubusercontent.com/80741/75094978-73857880-5590-11ea-81f6-a02088b932e6.png)

2. Before the fix, `b2` returns Zero

![image](https://user-images.githubusercontent.com/80741/75095010-ceb76b00-5590-11ea-8604-c19ea3608b63.png)

3. After the fix, `b2` returns non-Zero

![image](https://user-images.githubusercontent.com/80741/75094985-88620c00-5590-11ea-8f8d-aa4353c55f16.png)
