### PR TITLE
Switch to explicit ANSI variants of Win32 API functions

### DIFF
--- a/src/engine/debugger.cpp
+++ b/src/engine/debugger.cpp
@@ -772,7 +772,7 @@ static int get_module_filename( string * out )
     DWORD result;
     string_reserve( out, 256 + 1 );
     string_truncate( out, 256 );
-    while( ( result = GetModuleFileName( NULL, out->value, out->size ) ) == out->size )
+    while( ( result = GetModuleFileNameA( NULL, out->value, out->size ) ) == out->size )
     {
         string_reserve( out, out->size * 2 + 1);
         string_truncate( out, out->size * 2 );
@@ -1104,7 +1104,7 @@ static void debug_start_child( int argc, const char * * argv )
     string command_line[ 1 ];
     SECURITY_ATTRIBUTES sa = { sizeof( SECURITY_ATTRIBUTES ), NULL, TRUE };
     PROCESS_INFORMATION pi = { NULL, NULL, 0, 0 };
-    STARTUPINFO si = { sizeof( STARTUPINFO ), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    STARTUPINFOA si = { sizeof( STARTUPINFOA ), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0 };
     assert( debug_state == DEBUG_NO_CHILD );
     if ( ! CreatePipe( &pipe1[ 0 ], &pipe1[ 1 ], &sa, 0 ) )
@@ -1149,7 +1149,7 @@ static void debug_start_child( int argc, const char * * argv )
     }
     SetHandleInformation( pipe1[ 1 ], HANDLE_FLAG_INHERIT, 0 );
     SetHandleInformation( pipe2[ 0 ], HANDLE_FLAG_INHERIT, 0 );
-    if ( ! CreateProcess(
+    if ( ! CreateProcessA(
         self->value,
         command_line->value,
         NULL,

--- a/src/engine/execnt.cpp
+++ b/src/engine/execnt.cpp
@@ -488,7 +488,7 @@ static void invoke_cmd( char const * const command, int const slot )
 {
     SECURITY_ATTRIBUTES sa = { sizeof( SECURITY_ATTRIBUTES ), 0, 0 };
     SECURITY_DESCRIPTOR sd;
-    STARTUPINFO si = { sizeof( STARTUPINFO ), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    STARTUPINFOA si = { sizeof( STARTUPINFOA ), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0 };
 
     /* Init the security data. */
@@ -1079,10 +1079,20 @@ static int is_parent_child( DWORD const parent, DWORD const child )
                  * id == 4. This check must be performed before comparing
                  * process creation times.
                  */
+
+#ifdef UNICODE  // no PROCESSENTRY32A
+                if ( !wcsicmp( pinfo.szExeFile, L"csrss.exe" ) &&
+#else
                 if ( !stricmp( pinfo.szExeFile, "csrss.exe" ) &&
+#endif
                     is_parent_child( parent, pinfo.th32ParentProcessID ) == 2 )
                     return 1;
+
+#ifdef UNICODE  // no PROCESSENTRY32A
+                if ( !wcsicmp( pinfo.szExeFile, L"smss.exe" ) &&
+#else
                 if ( !stricmp( pinfo.szExeFile, "smss.exe" ) &&
+#endif
                     ( pinfo.th32ParentProcessID == 4 ) )
                     return 2;
 

--- a/src/engine/filent.cpp
+++ b/src/engine/filent.cpp
@@ -98,7 +98,7 @@ int file_collect_dir_content_( file_info_t * const d )
         /* FIXME: Avoid duplicate FindXXX Windows API calls here and in the code
          * determining a normalized path.
          */
-        WIN32_FIND_DATA finfo;
+        WIN32_FIND_DATAA finfo;
         HANDLE const findHandle = FindFirstFileA( pathspec->value, &finfo );
         if ( findHandle == INVALID_HANDLE_VALUE )
         {
@@ -142,7 +142,7 @@ int file_collect_dir_content_( file_info_t * const d )
                 }
             }
         }
-        while ( FindNextFile( findHandle, &finfo ) );
+        while ( FindNextFileA( findHandle, &finfo ) );
 
         FindClose( findHandle );
     }

--- a/src/engine/jam.cpp
+++ b/src/engine/jam.cpp
@@ -727,7 +727,7 @@ int main( int argc, char * * argv, char * * arg_environ )
 char * executable_path( char const * argv0 )
 {
     char buf[ 1024 ];
-    DWORD const ret = GetModuleFileName( NULL, buf, sizeof( buf ) );
+    DWORD const ret = GetModuleFileNameA( NULL, buf, sizeof( buf ) );
     return ( !ret || ret == sizeof( buf ) ) ? NULL : strdup( buf );
 }
 #elif defined(__APPLE__)  /* Not tested */

--- a/src/engine/pathnt.cpp
+++ b/src/engine/pathnt.cpp
@@ -174,7 +174,7 @@ static int canonicWindowsPath( char const * const path, int const path_length,
         if ( !( n_length == 1 && n[ 0 ] == '.' )
             && !( n_length == 2 && n[ 0 ] == '.' && n[ 1 ] == '.' ) )
         {
-            WIN32_FIND_DATA fd;
+            WIN32_FIND_DATAA fd;
             HANDLE const hf = FindFirstFileA( out->value, &fd );
             if ( hf != INVALID_HANDLE_VALUE )
             {

--- a/src/engine/w32_getreg.cpp
+++ b/src/engine/w32_getreg.cpp
@@ -65,7 +65,7 @@ LIST * builtin_system_registry( FRAME * frame, int flags )
 
     if (
         key != 0
-        && ERROR_SUCCESS == RegOpenKeyEx(key, path, 0, KEY_QUERY_VALUE, &key)
+        && ERROR_SUCCESS == RegOpenKeyExA(key, path, 0, KEY_QUERY_VALUE, &key)
     )
     {
         DWORD  type;
@@ -74,7 +74,7 @@ LIST * builtin_system_registry( FRAME * frame, int flags )
         LIST * const field = lol_get(frame->args, 1);
 
         if ( ERROR_SUCCESS ==
-             RegQueryValueEx(key, field ? object_str( list_front( field ) ) : 0, 0, &type, data, &len) )
+             RegQueryValueExA(key, field ? object_str( list_front( field ) ) : 0, 0, &type, data, &len) )
         {
             switch (type)
             {
@@ -86,7 +86,7 @@ LIST * builtin_system_registry( FRAME * frame, int flags )
                      string_new(expanded);
 
                      while (
-                         (len = ExpandEnvironmentStrings(
+                         (len = ExpandEnvironmentStringsA(
                              (LPCSTR)data, expanded->value, expanded->capacity))
                          > expanded->capacity
                      )
@@ -132,7 +132,7 @@ static LIST* get_subkey_names(HKEY key, char const* path)
     LIST* result = 0;
 
     if ( ERROR_SUCCESS ==
-         RegOpenKeyEx(key, path, 0, KEY_ENUMERATE_SUB_KEYS, &key)
+         RegOpenKeyExA(key, path, 0, KEY_ENUMERATE_SUB_KEYS, &key)
     )
     {
         char name[MAX_REGISTRY_KEYNAME_LENGTH];
@@ -141,7 +141,7 @@ static LIST* get_subkey_names(HKEY key, char const* path)
         FILETIME last_write_time;
 
         for ( index = 0;
-              ERROR_SUCCESS == RegEnumKeyEx(
+              ERROR_SUCCESS == RegEnumKeyExA(
                   key, index, name, &name_size, 0, 0, 0, &last_write_time);
               ++index,
               name_size = sizeof(name)
@@ -161,14 +161,14 @@ static LIST* get_value_names(HKEY key, char const* path)
 {
     LIST* result = 0;
 
-    if ( ERROR_SUCCESS == RegOpenKeyEx(key, path, 0, KEY_QUERY_VALUE, &key) )
+    if ( ERROR_SUCCESS == RegOpenKeyExA(key, path, 0, KEY_QUERY_VALUE, &key) )
     {
         char name[MAX_REGISTRY_VALUENAME_LENGTH];
         DWORD name_size = sizeof(name);
         DWORD index;
 
         for ( index = 0;
-              ERROR_SUCCESS == RegEnumValue(
+              ERROR_SUCCESS == RegEnumValueA(
                   key, index, name, &name_size, 0, 0, 0, 0);
               ++index,
               name_size = sizeof(name)


### PR DESCRIPTION
Allow clean compilation with `/DUNICODE` defined.

Fixes #542