### PR TITLE
Whoops ! Concatenate was not being done properly. I forgot to capture results.…

### DIFF
--- a/src/tools/embarcadero.jam
+++ b/src/tools/embarcadero.jam
@@ -417,8 +417,8 @@ local rule concatenate ( path : name )
     {
 
     local result ;
-    local has_ending_slash = [ MATCH ".*[/\\]$" : $(path) ] ;
-    local has_backward_slash = [ MATCH ".*[\\]" : $(path) ] ;
+    local has_ending_slash = [ MATCH ".*([/\\])$" : $(path) ] ;
+    local has_backward_slash = [ MATCH ".*([\\])" : $(path) ] ;
     
     if $(has_ending_slash)
         {


### PR DESCRIPTION
… This led to // in a file spec, which did not seem to harm anything but still needs to be fixed. Everything was still working but an executable path of "c:/somepath//someprogram.exe" etc. is not healthy in Windows even if the command processor allowed it.