### PR TITLE
The dinkumware library used by the Embarcadero clang-based compilers …

### DIFF
--- a/src/tools/embarcadero.jam
+++ b/src/tools/embarcadero.jam
@@ -157,6 +157,7 @@ toolset.inherit-flags embarcadero
       <stdlib>libc++
       <target-os>windows/<runtime-link>static
       <target-os>windows/<runtime-link>shared
+      <rtti>off
     ;
 
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ] {


### PR DESCRIPTION
…does not work with rtti turned off. I have reported this to Embarcadero as a potential bug but I strongly suspect that this is by design.