### PR TITLE
Fix compiler version check on macOS

### DIFF
--- a/src/tools/darwin.jam
+++ b/src/tools/darwin.jam
@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
     # - Set the toolset generic common options.
     common.handle-options darwin : $(condition) : $(command) : $(options) ;
     
+    real-version = [ regex.split $(real-version) \\. ] ;
     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
-    if $(real-version) < "4.0.0"
+    if [ version.version-less $(real-version) : 4 0 ]
     {
         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
     }
     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
-    if $(real-version) < "4.2.0"
+    if [ version.version-less $(real-version) : 4 2 ]
     {
         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
     }


### PR DESCRIPTION
Fixes #440.

This fixes Xcode 11.4 builds. `gcc` is just an alias to `clang` in Xcode, but `-dumpversion` returned a fixed 4.2.1 for compatibility reasons (the last version of `gcc` Xcode shipped). Xcode 11.4 changed this to now return the Apple Clang version, which is now 11.0.3. Because the version checks were a lexicographical comparison, "11.0.3" was seen as < "4.0.0".