### PR TITLE
Remove pch target naming restriction on GCC

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -638,18 +638,6 @@ class gcc-pch-generator : pch-generator
             }
         }
 
-        # Error handling: base header file name should be the same as the base
-        # precompiled header name.
-        local header-name = [ $(header).name ] ;
-        local header-basename = $(header-name:B) ;
-        if $(header-basename) != $(name)
-        {
-            local location = [ $(project).project-module ] ;
-            import errors : user-error : errors.user-error ;
-            errors.user-error "in" "$(location):" pch target name '$(name)' should
-                be the same as the base name of header file '$(header-name)' ;
-        }
-
         local pch-file = [ generator.run $(project) $(name) : $(property-set)
             : $(header) ] ;
 

--- a/test/pch.py
+++ b/test/pch.py
@@ -13,8 +13,8 @@ t = BoostBuild.Tester()
 
 t.write("jamroot.jam", """
 import pch ;
-cpp-pch pch : pch.hpp : <toolset>msvc:<source>pch.cpp <include>. ;
-exe hello : hello.cpp pch : <include>. ;
+cpp-pch pch-afx : pch.hpp : <toolset>msvc:<source>pch.cpp <include>. ;
+exe hello : hello.cpp pch-afx : <include>. ;
 """)
 
 t.write("pch.hpp.bad", """


### PR DESCRIPTION
Do not require pch target to have the same name as the header base name.

The restriction was added in 76d041d7c10938adbefd6fa045231ccfa79b3fc1 without a rationale and only for GCC while reworking PCH support for GCC and MSVC.

I have a use case in Spirit where I need multiple PCHs over the same header but with different macro definitions: https://github.com/boostorg/spirit/blob/390dbe2ec0324b834a29adfaed58319b909449d7/classic/test/Jamfile#L23-L25 and it is working on MSVC but fires an error on GCC.