### PR TITLE
Add QNX target option to archiver command

### DIFF
--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -271,10 +271,16 @@ if [ os.name ] = NT
 #
 # Use qcc driver to create archive, see
 #     http://www.qnx.com/developers/docs/6.3.2/neutrino/utilities/q/qcc.html
+
+rule archive
+{
+    check-target-platform $(1) ;
+}
+
 actions piecemeal archive
 {
     $(RM) "$(<)"
-    "$(CONFIG_COMMAND)" -A "$(<)" "$(>)"
+    "$(CONFIG_COMMAND)" $(QCC-TARGET-PLATFORM) -A "$(<)" "$(>)"
 }
 
 


### PR DESCRIPTION
In addition to #568: archiver also needs the target select option.
Static libraries created without this option are unusable. More precisely, they can be usable or not, depending on combination of local compiler settings and properties in the build request.