### PR TITLE
Set CRLF line endings for .bat/.cmd files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,10 @@
 *.gitattributes text svneol=native#text/plain
 
 # Scriptish formats
-*.bat        text svneol=crlf#text/plain
+*.bat        text eol=crlf svneol=crlf#text/plain
 *.bsh        text svneol=native#text/x-beanshell
 *.cgi        text svneol=native#text/plain
-*.cmd        text svneol=native#text/plain
+*.cmd        text eol=crlf svneol=crlf#text/plain
 *.js         text svneol=native#text/javascript
 *.php        text svneol=native#text/x-php
 *.pl         text svneol=native#text/x-perl


### PR DESCRIPTION
Git does not understand `svneol`

Fixes #477