### PR TITLE
Replace `/Ox` with `/O2` and remove `/Zi`

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -33,7 +33,7 @@ call :Call_If_Exists "%B2_TOOLSET_ROOT%bin\VCVARS32.BAT"
 if not "_%B2_TOOLSET_ROOT%_" == "__" (
     set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
     )
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -48,7 +48,7 @@ if NOT "_%B2_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -67,7 +67,7 @@ if NOT "_%B2_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -109,7 +109,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -131,7 +131,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -153,7 +153,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /Zi /MT /TP /Feb2 /wd4996 /Ox /GL"
+set "B2_CXX=%CXX% /nologo /MT /TP /Feb2 /wd4996 /O2 /GL"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof


### PR DESCRIPTION
Reduces b2 executable size for 60% (1174KiB vs 465KiB)

`/O2` is essentially `/Ox /GF /Gy`
`/Zi` implies `/debug` which disables `/opt` optimizations

Ping me if you prefer to add `/opt:ref,icf,lbr` instead of removing `/Zi`