### PR TITLE
Use /Zc:inline and /Zc:throwingNew flags

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -454,6 +454,14 @@ rule configure-version-specific ( toolset : version : conditions )
         }
     }
 
+    # 12.0 (VS2013 Update 2) introduced /Zc:inline opt-in standard conformance
+    # compiler flag that also similar to linker /opt:ref removes unreferenced
+    # variables and functions that have internal linkage
+    if ! [ MATCH "^(1[01]|\d)\\." : $(version) ]
+    {
+        toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:inline" ;
+    }
+
     #
     # Processor-specific optimization.
     #

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -462,6 +462,13 @@ rule configure-version-specific ( toolset : version : conditions )
         toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:inline" ;
     }
 
+    # 14.0 introduced /Zc:throwingNew opt-in flag that disables a workaround
+    # for not throwing operator new in VC up to 6.0
+    if ! [ MATCH "^(1[0-3]|\d)\\." : $(version) ]
+    {
+        toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:throwingNew" ;
+    }
+
     #
     # Processor-specific optimization.
     #

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -229,6 +229,7 @@ import set ;
 import toolset ;
 import type ;
 import virtual-target ;
+import version ;
 
 
 type.register MANIFEST : manifest ;
@@ -457,14 +458,14 @@ rule configure-version-specific ( toolset : version : conditions )
     # 12.0 (VS2013 Update 2) introduced /Zc:inline opt-in standard conformance
     # compiler flag that also similar to linker /opt:ref removes unreferenced
     # variables and functions that have internal linkage
-    if ! [ MATCH "^(1[01]|\d)\\." : $(version) ]
+    if ! [ version.version-less [ SPLIT_BY_CHARACTERS $(version) : . ] : 12 ]
     {
         toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:inline" ;
     }
 
     # 14.0 introduced /Zc:throwingNew opt-in flag that disables a workaround
     # for not throwing operator new in VC up to 6.0
-    if ! [ MATCH "^(1[0-3]|\d)\\." : $(version) ]
+    if ! [ version.version-less [ SPLIT_BY_CHARACTERS $(version) : . ] : 14 ]
     {
         toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:throwingNew" ;
     }


### PR DESCRIPTION
Size differences of `b2 toolset=msvc-14.2 variant=release link=shared,static`

flags              | bin.v2/libs   | diff | lib         | diff | dll        | diff
-------------------|--------------:|-----:|------------:|-----:|-----------:|-----:
no                 | 1 268 748 304 |      | 393 665 694 |      | 11 630 592 |  
inline	           |   757 974 914 | -40% | 173 383 766 | -56% | 11 615 744 | -0.1%
inline+throwingNew |   757 909 662 |  -0% | 173 444 188 |  +0% | 11 590 144 | -0.2%

Timings were 765s/732s/757s

Links to docs:
https://docs.microsoft.com/en-us/cpp/build/reference/zc-inline-remove-unreferenced-comdat?view=vs-2019
https://docs.microsoft.com/en-us/cpp/build/reference/zc-throwingnew-assume-operator-new-throws?view=vs-2019