### PR TITLE
fix(configure): add relevant feature to build a simple check program

### DIFF
--- a/src/build/configure.jam
+++ b/src/build/configure.jam
@@ -41,7 +41,7 @@ feature.feature configure : : composite optional ;
 # relevant features are also considered relevant.
 #
 feature.compose <configure> :
-    <target-os> <toolset> <address-model> <architecture> <cxxstd> ;
+    <target-os> <toolset> <address-model> <architecture> <cxxstd> <variant> <link> <runtime-link> <define> ;
 
 
 rule log-summary ( )


### PR DESCRIPTION
when checking if a lib is available by linking an executable, we have to
build with the same variant/link/define that the final build.