### PR TITLE
WIP: Force parse_file to exit early on parsing errors - but how?

### DIFF
--- a/src/engine/debugger.cpp
+++ b/src/engine/debugger.cpp
@@ -700,7 +700,8 @@ static void debug_child_print( int argc, const char * * argv )
     string_append( buf, " ;\n" );
     lines[ 0 ] = buf->value;
     lines[ 1 ] = NULL;
-    parse_string( constant_builtin, lines, &new_frame );
+    int status = 0; /* discarded */
+    status = parse_string( constant_builtin, lines, &new_frame );
     string_free( buf );
     debug_list_write( command_output, debug_print_result );
     fflush( command_output );

--- a/src/engine/jam.cpp
+++ b/src/engine/jam.cpp
@@ -646,7 +646,7 @@ int main( int argc, char * * argv, char * * arg_environ )
             }
 
             if ( !n )
-                parse_file( constant_plus, frame );
+                status = parse_file( constant_plus, frame );
         }
 
         /* FIXME: What shall we do if builtin_update_now,
@@ -654,26 +654,32 @@ int main( int argc, char * * argv, char * * arg_environ )
          * failed earlier?
          */
 
-        status = yyanyerrors();
+        if ( ! status )
+            status = last_update_now_status;
+
         if ( !status )
         {
-            /* Manually touch -t targets. */
-            for ( n = 0; ( s = getoptval( optv, 't', n ) ); ++n )
+            status = yyanyerrors();
+            if ( !status )
             {
-                OBJECT * const target = object_new( s );
-                touch_target( target );
-                object_free( target );
-            }
+                /* Manually touch -t targets. */
+                for ( n = 0; ( s = getoptval( optv, 't', n ) ); ++n )
+                {
+                    OBJECT * const target = object_new( s );
+                    touch_target( target );
+                    object_free( target );
+                }
 
-            /* Now make target. */
-            {
-                PROFILE_ENTER( MAIN_MAKE );
-                LIST * const targets = targets_to_update();
-                if ( !list_empty( targets ) )
-                    status |= make( targets, anyhow );
-                else
-                    status = last_update_now_status;
-                PROFILE_EXIT( MAIN_MAKE );
+                /* Now make target. */
+                {
+                    PROFILE_ENTER( MAIN_MAKE );
+                    LIST * const targets = targets_to_update();
+                    if ( !list_empty( targets ) )
+                        status |= make( targets, anyhow );
+                    else
+                        status = last_update_now_status;
+                    PROFILE_EXIT( MAIN_MAKE );
+                }
             }
         }
 

--- a/src/engine/parse.h
+++ b/src/engine/parse.h
@@ -67,8 +67,8 @@ struct _PARSE {
     int      line;
 };
 
-void parse_file( OBJECT *, FRAME * );
-void parse_string( OBJECT * name, const char * * lines, FRAME * frame );
+int parse_file( OBJECT *, FRAME * );
+int parse_string( OBJECT * name, const char * * lines, FRAME * frame );
 void parse_save( PARSE * );
 
 PARSE * parse_make( int type, PARSE * left, PARSE * right, PARSE * third,


### PR DESCRIPTION
This is a quick incomplete evaluation of how to report `status` code from calls rooted at `parse_file` in order to let quit b2 as early as possible.

PROBLEM:
How to early abort `function_run` on error?
The status returned from `parse_file` there is ignored.

Currently Jamfile parsing errors do not stop b2 which continues and reports non-zero exit code at the end of the whole build.
This is not user-friendly behaviour especially if user ignores exit code and ignores parsing errors reported at the top of the b2 output (e.g. issue #585).

By the way, `-q` option for quick quit does not stop b2 on parsing errors, it is not related to this phase at all.
If early exit on parsing errors is feasible, then `-q` semantics could be extended to those errors too.