### PR TITLE
Remove leftover manifest generation early exiting

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -7,6 +7,7 @@
 # Copyright (c) 2008 Jurko Gospodnetic
 # Copyright (c) 2014 Microsoft Corporation
 # Copyright (c) 2019 Michał Janiszewski
+# Copyright (c) 2020 Nikita Kniazev
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
@@ -822,7 +823,6 @@ if [ os.name ] in NT
     actions link bind DEF_FILE LIBRARIES_MENTIONED_BY_FILE
     {
         $(.SETUP) $(.LD) $(LINKFLAGS) /out:"$(<[1]:W)" /LIBPATH:"$(LINKPATH:W)" $(OPTIONS) @"@($(<[1]:W).rsp:E=$(.nl)"$(>)" $(.nl)$(LIBRARIES_MENTIONED_BY_FILE) $(.nl)$(LIBRARIES) $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_ST).lib" $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_SA).lib")"
-        if %ERRORLEVEL% NEQ 0 EXIT %ERRORLEVEL%
     }
 
     actions manifest
@@ -840,7 +840,6 @@ if [ os.name ] in NT
     actions link.dll bind IMPORT_LIB DEF_FILE LIBRARIES_MENTIONED_BY_FILE
     {
         $(.SETUP) $(.LD) /DLL $(LINKFLAGS) /out:"$(<[1]:W)" /IMPLIB:"$(IMPORT_LIB:W)" /LIBPATH:"$(LINKPATH:W)" /def:"$(DEF_FILE)" $(OPTIONS) @"@($(<[1]:W).rsp:E=$(.nl)"$(>)" $(.nl)$(LIBRARIES_MENTIONED_BY_FILE) $(.nl)$(LIBRARIES) $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_ST).lib" $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_SA).lib")"
-        if %ERRORLEVEL% NEQ 0 EXIT %ERRORLEVEL%
     }
 
     actions manifest.dll

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -818,7 +818,6 @@ rule link.dll ( targets + : sources * : properties * )
 # assemblies and Windows native DLLs. The manifests are embedded as resources
 # and are useful in any PE target (both DLL and EXE).
 
-if [ os.name ] in NT
 {
     actions link bind DEF_FILE LIBRARIES_MENTIONED_BY_FILE
     {
@@ -843,32 +842,6 @@ if [ os.name ] in NT
     actions manifest.dll
     {
         $(.SETUP) $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);2"
-    }
-    actions manifest.dll.user bind EMBED_MANIFEST_FILE
-    {
-        $(.SETUP) $(.MT) -manifest "$(EMBED_MANIFEST_FILE)" "-outputresource:$(<[1]);2"
-    }
-}
-else
-{
-    actions link bind DEF_FILE LIBRARIES_MENTIONED_BY_FILE
-    {
-        $(.SETUP) $(.LD) $(LINKFLAGS) /out:"$(<[1]:W)" /LIBPATH:"$(LINKPATH:W)" $(OPTIONS) @"@($(<[1]:W).rsp:E=$(.nl)"$(>)" $(.nl)$(LIBRARIES_MENTIONED_BY_FILE) $(.nl)$(LIBRARIES) $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_ST).lib" $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_SA).lib")"
-    }
-
-    actions manifest
-    {
-        $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);1"
-    }
-
-    actions link.dll bind IMPORT_LIB DEF_FILE LIBRARIES_MENTIONED_BY_FILE
-    {
-        $(.SETUP) $(.LD) /DLL $(LINKFLAGS) /out:"$(<[1]:W)" /IMPLIB:"$(IMPORT_LIB:W)" /LIBPATH:"$(LINKPATH:W)" /def:"$(DEF_FILE)" $(OPTIONS) @"@($(<[1]:W).rsp:E=$(.nl)"$(>)" $(.nl)$(LIBRARIES_MENTIONED_BY_FILE) $(.nl)$(LIBRARIES) $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_ST).lib" $(.nl)"$(LIBRARY_OPTION)$(FINDLIBS_SA).lib")"
-    }
-
-    actions manifest.dll
-    {
-        $(.SETUP) $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);2"
     }
 
     actions manifest.dll.user bind EMBED_MANIFEST_FILE

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -827,9 +827,7 @@ if [ os.name ] in NT
 
     actions manifest
     {
-        if exist "$(<[1]).manifest" (
-            $(.SETUP) $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);1"
-        )
+        $(.SETUP) $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);1"
     }
 
     actions manifest.user bind EMBED_MANIFEST_FILE
@@ -844,9 +842,7 @@ if [ os.name ] in NT
 
     actions manifest.dll
     {
-        if exist "$(<[1]).manifest" (
-            $(.SETUP) $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);2"
-        )
+        $(.SETUP) $(.MT) -manifest "$(<[1]).manifest" "-outputresource:$(<[1]);2"
     }
     actions manifest.dll.user bind EMBED_MANIFEST_FILE
     {
@@ -862,9 +858,7 @@ else
 
     actions manifest
     {
-        if test -e "$(<[1]).manifest"; then
-            $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);1"
-        fi
+        $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);1"
     }
 
     actions link.dll bind IMPORT_LIB DEF_FILE LIBRARIES_MENTIONED_BY_FILE
@@ -874,9 +868,7 @@ else
 
     actions manifest.dll
     {
-        if test -e "$(<[1]).manifest"; then
-            $(.SETUP) $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);2"
-        fi
+        $(.SETUP) $(.MT) -manifest "$(<[1]:W).manifest" "-outputresource:$(<[1]:W);2"
     }
 
     actions manifest.dll.user bind EMBED_MANIFEST_FILE


### PR DESCRIPTION
It should have been removed in dd3dbcc9b6d4d6322d693f58bb4306930fb19f68