### PR TITLE
apt-get -o Acquire::Retries=3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,8 +141,8 @@ stages:
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo -E apt-add-repository "deb http://apt.llvm.org/xenial/ ${LLVM_REPO} main"
           fi
-          sudo -E apt-get update
-          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
+          sudo -E apt-get -o Acquire::Retries=3 update
+          sudo -E apt-get -o Acquire::Retries=3 -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
       displayName: Install
     - bash: |
           set -e
@@ -381,8 +381,8 @@ stages:
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo -E apt-add-repository "deb http://apt.llvm.org/xenial/ ${LLVM_REPO} main"
           fi
-          sudo -E apt-get update
-          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
+          sudo -E apt-get -o Acquire::Retries=3 update
+          sudo -E apt-get -o Acquire::Retries=3 -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
       displayName: Install
     - bash: |
           set -e
@@ -438,8 +438,8 @@ stages:
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             sudo -E apt-add-repository "deb http://apt.llvm.org/xenial/ ${LLVM_REPO} main"
           fi
-          sudo -E apt-get update
-          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
+          sudo -E apt-get -o Acquire::Retries=3 update
+          sudo -E apt-get -o Acquire::Retries=3 -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
       displayName: Install
     - bash: |
           set -e


### PR DESCRIPTION
Should make CI more stable for https://dev.azure.com/grafikrobot/B2/_build/results?buildId=836&view=logs&j=9ffe4741-1780-5ea0-9451-76a228c3c533&t=ccc50abe-2b4b-59bf-5ed5-9446c5fd836f type of failures.