### PR TITLE
Pass /nologo to rc

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -175,7 +175,7 @@ rule init ( version ? : command * : options * )
         toolset.flags clang-win.archive .LD $(cond) : $(archiver) /nologo ;
         toolset.flags clang-win.link .MT $(cond) : $(manifest-tool) -nologo ;
         toolset.flags clang-win.compile .MC $(cond) : $(mc-compiler) ;
-        toolset.flags clang-win.compile .RC $(cond) : $(resource-compiler) /nologo ;
+        toolset.flags clang-win.compile .RC $(cond) : $(resource-compiler) ;
         toolset.flags clang-win.compile .IDL $(cond) : $(idl-compiler) ;
     }
 

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -751,7 +751,7 @@ rule compile.rc ( targets + : sources * : properties * )
 
 actions compile.rc
 {
-    $(.SETUP) $(.RC) -l 0x409 -U$(UNDEFS) -D$(DEFINES) -I"$(INCLUDES:W)" -fo "$(<:W)" "$(>:W)"
+    $(.SETUP) $(.RC) /nologo -l 0x409 -U$(UNDEFS) -D$(DEFINES) -I"$(INCLUDES:W)" -fo "$(<:W)" "$(>:W)"
 }
 
 toolset.uses-features msvc.link : <embed-manifest> <embed-manifest-file> ;


### PR DESCRIPTION
Supported at least with Resource Compiler Version 6.1.7600.16385 that comes in Windows SDK v7.0A, the oldest you could obtain nowadays.