### PR TITLE
Revert "Allow linking for gcc/mingw and clang targeting gcc on Windows to use response files to mitigate Windows command line limitations."

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -1,4 +1,3 @@
-#  Copyright 2020 Rene Rivera
 #  Copyright (c) 2003      Michael Stevens
 #  Copyright (c) 2010-2011 Bryce Lelbach (blelbach@cct.lsu.edu, maintainer)
 #
@@ -18,8 +17,6 @@ import errors ;
 import generators ;
 import type ;
 import numbers ;
-import os ;
-import property ;
 
 feature.extend-subfeature toolset clang : platform : linux ;
 
@@ -208,82 +205,19 @@ SPACE = " " ;
 rule link ( targets * : sources * : properties * ) {
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
-  
-  local tosw ;
-  local pselect = [ property.select <target-os> : $(properties) ] ;
-  
-  if $(pselect)
-    {
-    
-    local tosv = [ feature.get-values <target-os> : $(pselect) ] ;
-    
-    if $(tosv) = windows
-        {
-        tosw = 1 ;
-        }
-    }
-  else if [ os.name ] in NT
-    {
-    tosw = 1 ;
-    }
-  if $(tosw)
-    {
-    link-w $(targets) : $(sources) ;
-    }
-  else
-    {
-    link-o $(targets) : $(sources) ;
-    }
+}
+
+actions link bind LIBRARIES {
+    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,-R$(SPACE)-Wl,"$(RPATH)" -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -o "$(<)" $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)
 }
 
 rule link.dll ( targets * : sources * : properties * ) {
   SPACE on $(targets) = " " ;
   JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
-  
-  local tosw ;
-  local pselect = [ property.select <target-os> : $(properties) ] ;
-  
-  if $(pselect)
-    {
-    
-    local tosv = [ feature.get-values <target-os> : $(pselect) ] ;
-    
-    if $(tosv) = windows
-        {
-        tosw = 1 ;
-        }
-    }
-  else if [ os.name ] in NT
-    {
-    tosw = 1 ;
-    }
-  if $(tosw)
-    {
-    link.dll-w $(targets) : $(sources) ;
-    }
-  else
-    {
-    link.dll-o $(targets) : $(sources) ;
-    }
 }
 
-# Target OS is not Windows, needs the RPATH stuff
-actions link-o bind LIBRARIES {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @"@($(<[1]:T).rsp:E=-Wl,-R$(SPACE)-Wl,"$(RPATH)" -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" $(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
+# Differ from 'link' above only by -shared.
+actions link.dll bind LIBRARIES {
+    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,-R$(SPACE)-Wl,"$(RPATH)" -o "$(<)" -Wl,-soname$(SPACE)-Wl,$(<[1]:D=) -shared $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)
 }
 
-# Target OS is not Windows, needs the RPATH and SONAME stuff
-actions link.dll-o bind LIBRARIES {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @"@($(<[1]:T).rsp:E=-Wl,-R$(SPACE)-Wl,"$(RPATH)" -Wl,-soname$(SPACE)-Wl,$(<[1]:D=) -shared $(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
-}
-
-# Target OS is Windows, does not need the RPATH stuff
-actions link-w bind LIBRARIES {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @"@($(<[1]:T).rsp:E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
-}
-
-# Target OS is Windows, does not need the RPATH and SONAME stuff
-actions link.dll-w bind LIBRARIES {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" -shared @"@($(<[1]:T).rsp:E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
-    
-}

--- a/src/tools/embarcadero.jam
+++ b/src/tools/embarcadero.jam
@@ -393,9 +393,6 @@ rule init ( version ? :  command * : options * )
         local archiver ;
         local arflags ;
         local implib ;
-        local assembler ;
-        local asmflags ;
-        local asmoutput ;
         
         if $(compiler) = bcc32x
             {
@@ -404,16 +401,9 @@ rule init ( version ? :  command * : options * )
             archiver = tlib ;
             arflags = /P512 ;
             implib = implib ;
-            assembler = $(root)/bin/tasm32 ;
-            
-            # /ml makes all symbol names case-sensitive
-
-            asmflags = /ml ;
-            asmoutput = "," ;
             }
         else if $(compiler) = bcc64
             {
-            
             lib_dir_release = $(root)/lib/win64/release $(root)/lib/win64/release/psdk ;
             lib_dir_debug = $(root)/lib/win64/debug ;
             archiver = tlib64 ;
@@ -426,9 +416,7 @@ rule init ( version ? :  command * : options * )
         flags embarcadero.link LINKPATH $(condition)/<variant>debug : $(lib_dir_debug) $(lib_dir_release) ;
         flags embarcadero.archive .AR $(condition) : $(root)/bin/$(archiver) ;
         flags embarcadero.archive .ARFLAGS $(condition) : $(arflags) ;
-        flags embarcadero.asm .ASM $(condition) : $(assembler) ;
-        flags embarcadero.asm .ASMFLAGS $(condition) : $(asmflags) ;
-        flags embarcadero.asm .ASMOUTPUT $(condition) : $(asmoutput) ;
+        flags embarcadero.asm .TASM $(condition) : $(root)/bin/tasm32 ;
         flags embarcadero.asm USER_OPTIONS $(condition) : [ feature.get-values <asmflags> : $(options) ] ;
         flags embarcadero.archive AROPTIONS $(condition) : [ feature.get-values <archiveflags> : $(options) ] ;
         flags embarcadero.link.dll .IMPLIB_COMMAND $(condition) : $(root)/bin/$(implib) ;
@@ -519,15 +507,15 @@ local rule handle-options ( condition * : command * : options * )
             $(condition:E=(empty)) ;
     }
 
-    flags embarcadero CONFIG_COMMAND $(condition) : $(command) ;
+    toolset.flags embarcadero CONFIG_COMMAND $(condition) : $(command) ;
 
-    flags embarcadero.compile         OPTIONS $(condition) :
+    toolset.flags embarcadero.compile         OPTIONS $(condition) :
         [ feature.get-values <cflags>       : $(options) ] ;
 
-    flags embarcadero.compile.c++     OPTIONS $(condition) :
+    toolset.flags embarcadero.compile.c++     OPTIONS $(condition) :
         [ feature.get-values <cxxflags>     : $(options) ] ;
 
-    flags embarcadero.link            OPTIONS $(condition) :
+    toolset.flags embarcadero.link            OPTIONS $(condition) :
         [ feature.get-values <linkflags>    : $(options) ] ;
 }
 
@@ -547,8 +535,7 @@ generators.register-linker embarcadero.link.dll : OBJ SEARCHED_LIB STATIC_LIB IM
 generators.register-archiver embarcadero.archive : OBJ : STATIC_LIB : <toolset>embarcadero ;
 generators.register-c-compiler embarcadero.compile.c++ : CPP : OBJ : <toolset>embarcadero ;
 generators.register-c-compiler embarcadero.compile.c : C : OBJ : <toolset>embarcadero ;
-generators.register-c-compiler embarcadero.compile.asm : ASM : OBJ : <toolset>embarcadero <address-model>64 ;
-generators.register-standard embarcadero.asm : ASM : OBJ : <toolset>embarcadero <address-model>32 ;
+generators.register-standard embarcadero.asm : ASM : OBJ : <toolset>embarcadero ;
 
 # Flags
 
@@ -607,11 +594,11 @@ actions updated together piecemeal archive
 }
 
 rule link ( targets * : sources * : properties * ) {
-  JAM_SEMAPHORE on $(targets) = <s>embarcadero-link-semaphore ;
+  JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
 }
 
 rule link.dll ( targets * : sources * : properties * ) {
-  JAM_SEMAPHORE on $(targets) = <s>embarcadero-link-semaphore ;
+  JAM_SEMAPHORE on $(targets) = <s>clang-linux-link-semaphore ;
 }
 
 actions link bind LIBRARIES {
@@ -626,17 +613,8 @@ rule asm ( targets * : sources * : properties * )
 {
 }
 
+# /ml makes all symbol names case-sensitive
 actions asm
 {
-    $(.ASM) $(.ASMFLAGS) $(USER_OPTIONS) "$(>)" $(.ASMOUTPUT) "$(<)"
-}
-
-rule compile.asm ( targets * : sources * : properties * )
-{
-    LANG on $(<) = "-x assembler-with-cpp" ;
-}
-
-actions compile.asm
-{
-    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+    $(.TASM) /ml $(USER_OPTIONS) "$(>)" "$(<)"
 }

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -834,14 +834,14 @@ g = [ new gcc-linking-generator gcc.mingw.link
       : OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB
       : EXE
       : <toolset>gcc <target-os>windows ] ;
-$(g).set-rule-name gcc.link.mingw ;
+$(g).set-rule-name gcc.link ;
 generators.register $(g) ;
 
 g = [ new gcc-linking-generator gcc.mingw.link.dll
       : OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB
       : IMPORT_LIB SHARED_LIB
       : <toolset>gcc <target-os>windows ] ;
-$(g).set-rule-name gcc.link.dll.mingw ;
+$(g).set-rule-name gcc.link.dll ;
 generators.register $(g) ;
 
 generators.register
@@ -1103,6 +1103,11 @@ rule link ( targets * : sources * : properties * )
     quote-rpath $(targets) ;
 }
 
+actions link bind LIBRARIES
+{
+    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -o "$(<)" $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)
+}
+
 rule link.dll ( targets * : sources * : properties * )
 {
     SPACE on $(targets) = " " ;
@@ -1110,36 +1115,7 @@ rule link.dll ( targets * : sources * : properties * )
     quote-rpath $(targets) ;
 }
 
-rule link.mingw ( targets * : sources * : properties * )
-{
-    SPACE on $(targets) = " " ;
-    # Serialize execution of the 'link' action, since running N links in
-    # parallel is just slower. For now, serialize only gcc links, it might be a
-    # good idea to serialize all links.
-    JAM_SEMAPHORE on $(targets) = <s>gcc-link-semaphore ;
-}
-
-rule link.dll.mingw ( targets * : sources * : properties * )
-{
-    SPACE on $(targets) = " " ;
-    JAM_SEMAPHORE on $(targets) = <s>gcc-link-semaphore ;
-}
-
-actions link.mingw bind LIBRARIES
-{
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @"@($(<[1]:T).rsp:E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
-}
-
-actions link.dll.mingw bind LIBRARIES
-{
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" "$(.IMPLIB-COMMAND)$(<[1])" -o "$(<[-1])" -shared @"@($(<[-1]:T).rsp:E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP))" $(OPTIONS) $(USER_OPTIONS)
-}
-
-actions link bind LIBRARIES
-{
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -o "$(<)" $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)
-}
-
+# Differs from 'link' above only by -shared.
 actions link.dll bind LIBRARIES
 {
     "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) "$(.IMPLIB-COMMAND)$(<[1])" -o "$(<[-1])" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,$(<[-1]:D=) -shared $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -469,7 +469,7 @@ rule configure-version-specific ( toolset : version : conditions )
     # 12.0 (VS2013 Update 2) introduced /Zc:inline opt-in standard conformance
     # compiler flag that also similar to linker /opt:ref removes unreferenced
     # variables and functions that have internal linkage
-    if ! [ version.version-less [ SPLIT_BY_CHARACTERS [ MATCH "^([0123456789.]+)" : $(version) ] : . ] : 12 ]
+    if ! [ version.version-less [ SPLIT_BY_CHARACTERS $(version) : . ] : 12 ]
     {
         toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:inline" ;
 
@@ -479,7 +479,7 @@ rule configure-version-specific ( toolset : version : conditions )
 
     # 14.0 introduced /Zc:throwingNew opt-in flag that disables a workaround
     # for not throwing operator new in VC up to 6.0
-    if ! [ version.version-less [ SPLIT_BY_CHARACTERS [ MATCH "^([0123456789.]+)" : $(version) ] : . ] : 14 ]
+    if ! [ version.version-less [ SPLIT_BY_CHARACTERS $(version) : . ] : 14 ]
     {
         toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:throwingNew" ;
     }
@@ -527,7 +527,7 @@ rule configure-version-specific ( toolset : version : conditions )
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-arm)   : "/MACHINE:ARM" ;
         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-arm64) : "/MACHINE:ARM64" ;
 
-        if [ version.version-less [ SPLIT_BY_CHARACTERS [ MATCH "^([0123456789.]+)" : $(version) ] : . ] : 11 ]
+        if [ version.version-less [ SPLIT_BY_CHARACTERS $(version) : . ] : 11 ]
         {
             # Make sure that manifest will be generated even if there is no
             # dependencies to put there.

--- a/test/toolset-mock/src/clang-linux-3.9.0.py
+++ b/test/toolset-mock/src/clang-linux-3.9.0.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 #
 # Copyright 2017 Steven Watanabe
-# Copyright 2020 Rene Rivera
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
@@ -14,36 +13,36 @@ command('clang++', '-print-prog-name=ranlib', stdout=script('ranlib.py'))
 
 if allow_properties('variant=debug', 'link=shared', 'threading=single', 'runtime-link=shared'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/lib.o'), input_file(source='lib.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/libl1.so'), arg_file('@bin/clang-linux-3.9.0/debug*/libl1.so.rsp'), unordered('-g', '-fPIC'))
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/libl1.so'), '-Wl,-soname', '-Wl,libl1.so', '-shared', '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/lib.o'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-g', '-fPIC'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/test'), arg_file('@bin/clang-linux-3.9.0/debug*/test.rsp'), unordered('-g', '-fPIC'))
+    command('clang++', '-Wl,-R', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/libl1.so')), '-Wl,-rpath-link', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/libl1.so')), '-o', output_file('bin/clang-linux-3.9.0/debug/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/main.o'), input_file('bin/clang-linux-3.9.0/debug/libl1.so'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-g', '-fPIC'))
 
 if allow_properties('variant=release', 'link=shared', 'threading=single', 'runtime-link=shared', 'strip=on'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O3', '-Wno-inline', '-Wall', '-fPIC', '-DNDEBUG', '-c'), '-o', output_file('bin/clang-linux-3.9.0/release/lib.o'), input_file(source='lib.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/release/strip-on/libl1.so'), arg_file('@bin/clang-linux-3.9.0/release/strip-on*/libl1.so.rsp'), unordered('-fPIC', '-Wl,--strip-all'))
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/release/libl1.so'), '-Wl,-soname', '-Wl,libl1.so', '-shared', '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/release/lib.o'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-fPIC', '-Wl,--strip-all'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O3', '-Wno-inline', '-Wall', '-fPIC', '-DNDEBUG', '-c'), '-o', output_file('bin/clang-linux-3.9.0/release/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/release/test'), arg_file('@bin/clang-linux-3.9.0/release/strip-on*/test.rsp'), unordered('-fPIC', '-Wl,--strip-all'))
+    command('clang++', '-Wl,-R', arg('-Wl,', target_path('bin/clang-linux-3.9.0/release/libl1.so')), '-Wl,-rpath-link', arg('-Wl,', target_path('bin/clang-linux-3.9.0/release/libl1.so')), '-o', output_file('bin/clang-linux-3.9.0/release/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/release/main.o'), input_file('bin/clang-linux-3.9.0/release/libl1.so'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-fPIC', '-Wl,--strip-all'))
 
 if allow_properties('variant=debug', 'link=shared', 'threading=multi', 'runtime-link=shared'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-pthread', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/lib.o'), input_file(source='lib.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/libl1.so'), arg_file('@bin/clang-linux-3.9.0/debug*/threading-multi/libl1.so.rsp'), unordered('-g', '-pthread', '-fPIC'))
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/libl1.so'), '-Wl,-soname', '-Wl,libl1.so', '-shared', '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/threading-multi/lib.o'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-lrt', '-Wl,--end-group', unordered('-g', '-pthread', '-fPIC'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-pthread', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/test'), arg_file('@bin/clang-linux-3.9.0/debug*/threading-multi/test.rsp'), unordered('-g', '-pthread', '-fPIC'))
+    command('clang++', '-Wl,-R', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/threading-multi/libl1.so')), '-Wl,-rpath-link', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/threading-multi/libl1.so')), '-o', output_file('bin/clang-linux-3.9.0/debug/threading-multi/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/threading-multi/main.o'), input_file('bin/clang-linux-3.9.0/debug/threading-multi/libl1.so'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-lrt', '-Wl,--end-group', unordered('-g', '-pthread', '-fPIC'))
 
 if allow_properties('variant=debug', 'link=static', 'threading=single', 'runtime-link=shared'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/lib.o'), input_file(source='lib.cpp'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/test'), arg_file('@bin/clang-linux-3.9.0/debug/link-static*/test.rsp'), '-g')
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/link-static/main.o'), input_file('bin/clang-linux-3.9.0/debug/link-static/libl1.a'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', '-g')
 
 if allow_properties('variant=debug', 'link=static', 'threading=single', 'runtime-link=static'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/lib.o'), input_file(source='lib.cpp'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/test'), arg_file('@bin/clang-linux-3.9.0/debug/link-static/runtime-link-static*/test.rsp'), unordered('-g', '-static'))
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/main.o'), input_file('bin/clang-linux-3.9.0/debug/link-static/runtime-link-static/libl1.a'), '-Wl,--end-group', unordered('-g', '-static'))
 
 if allow_properties('variant=debug', 'link=shared', 'threading=single', 'runtime-link=shared', 'architecture=x86', 'address-model=32'):
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-march=i686', '-m32', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/lib.o'), input_file(source='lib.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/libl1.so'), arg_file('@bin/clang-linux-3.9.0/debug/address-model-32/architecture-x86*/libl1.so.rsp'), unordered('-g', '-march=i686', '-fPIC', '-m32'))
+    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/libl1.so'), '-Wl,-soname', '-Wl,libl1.so', '-shared', '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/lib.o'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-g', '-march=i686', '-fPIC', '-m32'))
     command('clang++', unordered(ordered('-x', 'c++'), '-O0', '-fno-inline', '-Wall', '-g', '-march=i686', '-m32', '-fPIC', '-c'), '-o', output_file('bin/clang-linux-3.9.0/debug/main.o'), input_file(source='main.cpp'))
-    command('clang++', '-o', output_file('bin/clang-linux-3.9.0/debug/test'), arg_file('@bin/clang-linux-3.9.0/debug/address-model-32/architecture-x86*/test.rsp'), unordered('-g', '-march=i686', '-fPIC', '-m32'))
+    command('clang++', '-Wl,-R', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/libl1.so')), '-Wl,-rpath-link', arg('-Wl,', target_path('bin/clang-linux-3.9.0/debug/libl1.so')), '-o', output_file('bin/clang-linux-3.9.0/debug/test'), '-Wl,--start-group', input_file('bin/clang-linux-3.9.0/debug/main.o'), input_file('bin/clang-linux-3.9.0/debug/libl1.so'), '-Wl,-Bstatic', '-Wl,-Bdynamic', '-Wl,--end-group', unordered('-g', '-march=i686', '-fPIC', '-m32'))
 
 main()


### PR DESCRIPTION
Reverts boostorg/build#567

The PR introduced unjustified response files usage on Linux platform.