### PR TITLE
Erase -brtl for AIX

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -916,12 +916,6 @@ toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib
 
     # On AIX we *have* to use the native linker.
     #
-    # Using -brtl, the AIX linker will look for libraries with both the .a
-    # and .so extensions, such as libfoo.a and libfoo.so. Without -brtl, the
-    # AIX linker looks only for libfoo.a. Note that libfoo.a is an archived
-    # file that may contain shared objects and is different from static libs
-    # as on Linux.
-    #
     # The -bnoipath strips the prepending (relative) path of libraries from
     # the loader section in the target library or executable. Hence, during
     # load-time LIBPATH (identical to LD_LIBRARY_PATH) or a hard-coded
@@ -939,7 +933,7 @@ toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib
     # AIX 4.x and AIX 6.x. For details about the AIX linker see:
     # http://download.boulder.ibm.com/ibmdl/pub/software/dw/aix/es-aix_ll.pdf
     #
-    toolset.flags gcc.link OPTIONS <target-os>aix : -Wl,-brtl -Wl,-bnoipath -Wl,-bbigtoc ;
+    toolset.flags gcc.link OPTIONS <target-os>aix : -Wl,-bnoipath -Wl,-bbigtoc ;
 
     # See note [1]
     toolset.flags gcc.link OPTIONS <target-os>aix/<runtime-link>static : -static ;


### PR DESCRIPTION
Hello,

OS: AIX 7.1
Compiler: GCC 8.4

I am building Boost on AIX. Our goal is to distribute it throught website for OpenSource software, like http://www.bullfreeware.com/ or https://www.ibm.com/support/pages/node/882892.
Up to now, Boost Build uses the -brtl flag.

We do not want -brtl as this flag decreases performances, and boost do not need it. So, -brtl must be added by a project only if the project needs it, and not as a default by b2. All librarires tested works without -brtl.

Without -brtl, AIX linker looks only for archive file .a containg shared libraries (typically .so or .so.version). It is the default and normal behavior. All software distributed on AIX must provide .a and not just .so. If a project needs .so and do not want to put it on an archive, the project can add -brtl, but it might not be added by default.