### PR TITLE
Aix lib

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -1142,7 +1142,15 @@ actions link bind LIBRARIES
 
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) "$(.IMPLIB-COMMAND)$(<[1])" -o "$(<[-1])" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,$(<[-1]:D=) -shared $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS)
+    (
+    FILE=$(<[-1]);
+    if [ "$FILE" == "${FILE%%.a*}" ]; then
+      "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<[-1])" -shared $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS) ;
+    else
+      "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "${FILE%%.a*}.so${FILE##*.a}" -shared $(START-GROUP) "$(>)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS) ;
+      ar -X32_64 -qc "$(<[-1])" "${FILE%%.a*}.so${FILE##*.a}"
+    fi
+    )
 }
 
 ###

--- a/src/tools/types/lib.jam
+++ b/src/tools/types/lib.jam
@@ -30,13 +30,17 @@ import os ;
 type.register LIB ;
 
 # FIXME: should not register both extensions on both platforms.
-type.register STATIC_LIB : a lib : LIB ;
+type.register STATIC_LIB : static.a lib : LIB ;
 
 # The 'lib' prefix is used everywhere
 type.set-generated-target-prefix STATIC_LIB : : lib ;
 
 # Use '.lib' suffix for windows
 type.set-generated-target-suffix STATIC_LIB : <target-os>windows : lib ;
+
+# AIX has .a for both shared and static.
+# b2 does not accept...
+type.set-generated-target-suffix STATIC_LIB : <target-os>aix : static.a ;
 
 # Except with gcc.
 type.set-generated-target-suffix STATIC_LIB : <toolset>gcc <target-os>windows : a ;
@@ -50,7 +54,7 @@ type.set-generated-target-suffix IMPORT_LIB : : lib ;
 type.set-generated-target-prefix IMPORT_LIB : <toolset>gcc : lib ;
 type.set-generated-target-suffix IMPORT_LIB : <toolset>gcc : dll.a ;
 
-type.register SHARED_LIB : so dll dylib : LIB ;
+type.register SHARED_LIB : so dll dylib a : LIB ;
 
 # Both mingw and cygwin use libxxx.dll naming scheme.
 # On Linux, use "lib" prefix
@@ -66,6 +70,7 @@ type.set-generated-target-prefix SHARED_LIB : <target-os>cygwin : cyg ;
 type.set-generated-target-suffix SHARED_LIB : <target-os>windows : dll ;
 type.set-generated-target-suffix SHARED_LIB : <target-os>cygwin : dll ;
 type.set-generated-target-suffix SHARED_LIB : <target-os>darwin : dylib ;
+type.set-generated-target-suffix SHARED_LIB : <target-os>aix : a ;
 
 type SEARCHED_LIB : : LIB ;
 # This is needed so that when we create a target of SEARCHED_LIB


### PR DESCRIPTION
Hello,

OS: AIX 7.1
Compiler: GCC 8.4

I am building Boost on AIX. Our goal is to distribute it through website for OpenSource software, like http://www.bullfreeware.com/ or https://www.ibm.com/support/pages/node/882892.
Up to now, Boost Build produces libraries as .so on AIX. It is not the normal way on AIX.

A shared library must be distributed as an archive (.a) containing a shared object (typically .so or .so.version).
I have a proof of work to do this. However, I fade some limitation, and I want to know how to do this in a better way.

With my modifications, the real target is the archive, and shared object are intermediate object. It is needed because only the real target is installed.
I use shell substitution to produce the right object from the target name as Boost Build tools (:S= and so on) seem not enough.

My troubles are the following:
- First, shared and static libraries cannot have the same prefix. On AIX, both are .a files. I have decided static libraries are .static.a, but it is a poor workaround.
- Second, I have modified the way a shared library is created to produce an archive immediately after (except for plugin, dlopened liraries). I do not found a way to apply this only on AIX.
- Third, the .so might be versioned, but not the .a. Eg, libbboost_foo.a contains libboost_foo.so.1.69.0. If I add a version to the target, the .a file will have a version (we do not want). Without version to the target, .so does not have. With .so as a target and .a produced additionally, .a is not installed.

If you has any idea to create shared libraries as archive on AIX with a better way, I am interested in.