### PR TITLE
Add missing relevant features for searched lib targets (Fixes #515)

### DIFF
--- a/src/tools/generators/searched-lib-generator.jam
+++ b/src/tools/generators/searched-lib-generator.jam
@@ -38,7 +38,7 @@ class searched-lib-generator : generator
 
             local search = [ feature.get-values <search> : $(properties) ] ;
 
-            local a = [ new null-action [ $(property-set).add-raw <relevant>link ] ] ;
+            local a = [ new null-action [ $(property-set).add-raw <relevant>link <relevant>search ] ] ;
             local lib-name = [ feature.get-values <name> : $(properties) ] ;
             lib-name ?= $(name) ;
             local t = [ new searched-lib-target $(lib-name) : $(project)
@@ -47,7 +47,7 @@ class searched-lib-generator : generator
             #    lib png : z : <name>png ;
             # the 'z' target should be returned, so that apps linking to 'png'
             # will link to 'z', too.
-            return [ property-set.create <xdll-path>$(search) <relevant>link ]
+            return [ property-set.create <xdll-path>$(search) <relevant>link <relevant>search <relevant>name ]
                    [ virtual-target.register $(t) ] $(sources) ;
         }
     }
@@ -88,7 +88,7 @@ class searched-lib-target : abstract-file-target
 
     rule relevant ( )
     {
-        return [ property-set.create <relevant>link ] ;
+        return [ property-set.create <relevant>link <relevant>search ] ;
     }
 
     rule path ( )

--- a/test/searched_lib.py
+++ b/test/searched_lib.py
@@ -163,6 +163,22 @@ lib l : : <name>l_f ;
 t.run_build_system(["-n"])
 
 
+# A regression test. Virtual targets distinguished by their search paths were
+# not differentiated when registered, which caused search paths to be selected
+# incorrectly for build requests with multiple feature values.
+t.write("jamroot.jam", "")
+t.write("a.cpp", "")
+t.write("jamfile.jam", """\
+exe a : a.cpp l ;
+lib l : : <name>l <search>lib32 <address-model>32 ;
+lib l : : <name>l <search>lib64 <address-model>64 ;
+""")
+
+t.run_build_system(["-n","address-model=32,64"])
+t.fail_test(t.stdout().find("lib32") == -1)
+t.fail_test(t.stdout().find("lib64") == -1)
+
+
 # Make sure plain "lib foobar ; " works.
 t.write("jamfile.jam", """\
 exe a : a.cpp foobar ;


### PR DESCRIPTION
These are the changes discussed in #515, verified for both address-model=32,64 and release+debug examples.