### PR TITLE
use '-arch arm64' for 64-bit builds using darwin.jam

### DIFF
--- a/src/tools/darwin.jam
+++ b/src/tools/darwin.jam
@@ -502,6 +502,8 @@ rule setup-address-model ( targets * : sources * : properties * )
         {
             if $(instruction-set) {
                 options = -arch$(_)$(instruction-set) ;
+            } else if $(address-model) = 64 {
+                options = -arch arm64 ;
             } else {
                 options = -arch arm ;
             }


### PR DESCRIPTION
Even for 64-bit architectures, b2 would add '-arch arm' to the compiler
options - but this is only valid for 32-bit arm builds.
The problem was also observed here: https://stackoverflow.com/a/47096479