### PR TITLE
Add quotes to fix shell error in src/engine/build.sh

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -77,8 +77,8 @@ test_exec ()
 # Check that the compiler can do C++11.
 test_cxx11 ()
 {
-    local CXX=${CXX}
-    local CXXFLAGS=${CXXFLAGS}
+    local CXX="${CXX}"
+    local CXXFLAGS="${CXXFLAGS}"
     if test ${NO_CXX_VARS} ; then
         CXX=
         CXXFLAGS=


### PR DESCRIPTION
Without these quotes, at least dash chokes on a multi-word `CXXFLAGS` variable.