### PR TITLE
Fix detection of MIPS32

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -412,9 +412,9 @@
 #endif
 
 #ifdef __mips__
-  #if defined(_ABI64)
+  #if _MIPS_SIM == _MIPS_SIM_ABI64
     #define OSPLAT "OSPLAT=MIPS64"
-  #elif defined(_ABIO32)
+  #elif _MIPS_SIM == _MIPS_SIM_ABI32
     #define OSPLAT "OSPLAT=MIPS32"
   #endif
 #endif


### PR DESCRIPTION
_ABI64 and _ABIO32 are always defined on every
Linux MIPS system, at least if it's glibc-based:

https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/sgidefs.h;h=c9e00c6da53b1a13d83b4056f01ef5c30efe76ab

The correct way to use them is to compare them
against _MIPS_SIM symbol provided by the compiler.

With this change, engine correctly detects 32-bit MIPS systems.