### PR TITLE
Fix memory leak in startup::bootstrap (boostorg#668)

### DIFF
--- a/src/engine/startup.cpp
+++ b/src/engine/startup.cpp
@@ -155,7 +155,12 @@ bool b2::startup::bootstrap(FRAME *frame)
         }
     }
 
-    const std::string b2_exe_path{executable_path(saved_argv0)};
+    char *b2_exe_path_pchar = executable_path(saved_argv0);
+    const std::string b2_exe_path{b2_exe_path_pchar};
+    if (b2_exe_path_pchar)
+    {
+        free(b2_exe_path_pchar);
+    }
     const std::string boost_build_jam{"boost-build.jam"};
     std::string b2_file_path;
 


### PR DESCRIPTION
The executable_path allocates a string (strdup) which was never released

Tested with ASAN and valgrind