### PR TITLE
Add missing include stdlib.h

### DIFF
--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -30,6 +30,7 @@
 #include "output.h"
 
 #include <ctype.h>
+#include <stdlib.h>
 
 #ifdef OS_NT
 #include <windows.h>

--- a/src/engine/startup.cpp
+++ b/src/engine/startup.cpp
@@ -14,6 +14,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include "output.h"
 #include "variable.h"
 
+#include <stdlib.h>
 #include <string>
 #include <algorithm>
 


### PR DESCRIPTION
The header is needed for `free()`.

Fixes https://github.com/boostorg/build/issues/671.