### PR TITLE
Ensure Embarcadero toolset name is only "embtc"

### DIFF
--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -929,6 +929,7 @@ local rule toolset-tag ( name : type ? : property-set )
         case cw : tag += cw ;
         case darwin* : tag += xgcc ;
         case edg* : tag += edg ;
+        case embarcadero* : tag += bcb ;
         case gcc* :
         {
             switch [ $(property-set).get <target-os> ]

--- a/src/tools/common.jam
+++ b/src/tools/common.jam
@@ -929,7 +929,7 @@ local rule toolset-tag ( name : type ? : property-set )
         case cw : tag += cw ;
         case darwin* : tag += xgcc ;
         case edg* : tag += edg ;
-        case embarcadero* : tag += bcb ;
+        case embarcadero* : tag += embtc ;
         case gcc* :
         {
             switch [ $(property-set).get <target-os> ]
@@ -996,6 +996,13 @@ local rule toolset-tag ( name : type ? : property-set )
 
     # On borland, version is not added for compatibility with V1.
     if $(tag) = bcb
+    {
+        version = ;
+    }
+
+    # Use un-versioned toolset name for Embarcadero, to avoid having to update
+    # the auto-linking logic on every release.
+    if $(tag) = embtc
     {
         version = ;
     }


### PR DESCRIPTION
This change, along with boostorg/config#346, fixes the expected library names in a versioned-layout build.