### PR TITLE
Update "borland" toolset for building B2 to bcc32c.exe

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -160,9 +160,9 @@ set "_known_=1"
 goto :eof
 
 :Config_BORLAND
-if not defined CXX ( set "CXX=bcc32" )
+if not defined CXX ( set "CXX=bcc32c" )
 if "_%B2_TOOLSET_ROOT%_" == "__" (
-    call guess_toolset.bat test_path bcc32.exe )
+    call guess_toolset.bat test_path bcc32c.exe )
 if "_%B2_TOOLSET_ROOT%_" == "__" (
     if not errorlevel 1 (
         set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
@@ -170,7 +170,7 @@ if "_%B2_TOOLSET_ROOT%_" == "__" (
 if not "_%B2_TOOLSET_ROOT%_" == "__" (
     set "PATH=%B2_TOOLSET_ROOT%Bin;%PATH%"
     )
-set "B2_CXX=%CXX% -tC -P -O2 -w- -I"%B2_TOOLSET_ROOT%Include" -L"%B2_TOOLSET_ROOT%Lib" -Nd -eb2"
+set "B2_CXX=%CXX% -tC -P -O2 -w- -I"%B2_TOOLSET_ROOT%Include" -L"%B2_TOOLSET_ROOT%Lib" -eb2"
 set "_known_=1"
 goto :eof
 

--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -85,11 +85,7 @@ if not errorlevel 1 (
     call "%FOUND_PATH%VCVARS32.BAT"
     set "B2_TOOLSET_ROOT=%MSVCDir%\"
     exit /b 0)
-if EXIST "C:\Borland\BCC55\Bin\bcc32.exe" (
-    set "B2_TOOLSET=borland"
-    set "B2_TOOLSET_ROOT=C:\Borland\BCC55\"
-    exit /b 0)
-call :Test_Path bcc32.exe
+call :Test_Path bcc32c.exe
 if not errorlevel 1 (
     set "B2_TOOLSET=borland"
     set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"


### PR DESCRIPTION
For bootstrapping `b2` itself, the current `borland` toolset is broken now as `bcc32.exe` doesn't support C++11. Update that toolset to use the Clang-based `bcc32c.exe`, which has largely the same cmdline args.