### PR TITLE
Adding top-level index.html which redirects to the doc/html/index.htm…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+<meta http-equiv="refresh" content="0; URL=doc/html/index.html">
+</head>
+<body>
+Automatic redirection failed, please go to
+<a href="doc/html/index.html">doc/html/index.html</a>.
+
+<!--
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+-->
+
+</body>
+</html>


### PR DESCRIPTION
…l, where the documentation gets built by default. A Boost release expects a top-level index.html brings up the documentation for a library or a tool.