### PR TITLE
Cygwin relpath fix

### DIFF
--- a/src/engine/jam.cpp
+++ b/src/engine/jam.cpp
@@ -747,7 +747,7 @@ char * executable_path( char const * argv0 )
     sysctl( mib, 4, buf, &size, NULL, 0 );
     return ( !size || size == sizeof( buf ) ) ? NULL : strndup( buf, size );
 }
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__CYGWIN__)
 # include <unistd.h>
 char * executable_path( char const * argv0 )
 {


### PR DESCRIPTION
It crashed otherwise (executable_path fallback). Should fix #684