### PR TITLE
Add missing case for <architecture>x86/<address-model>

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -167,7 +167,7 @@ rule init ( version ? : command * : options * )
         .notice "$(addr):" "using idl-compiler '$(idl-compiler)'" ;
 
         local cond = "$(condition)/<architecture>/<address-model>$(addr)" "$(condition)/<architecture>x86/<address-model>$(addr)" ;
-        if $(addr) = 32 { cond += "$(condition)/<architecture>/<address-model>" ; }
+        if $(addr) = 32 { cond += "$(condition)/<architecture>/<address-model>" "$(condition)/<architecture>x86/<address-model>" ; }
 
         toolset.flags clang-win.compile .CC $(cond) : $(compiler) -m$(addr) ;
         toolset.flags clang-win.link .LD $(cond) : $(compiler) -m$(addr) ;


### PR DESCRIPTION
This fixes the config check for the default address model which otherwise resulted in
```
compile-c-c++ ..\..\bin.v2\libs\config\checks\architecture\clang-win-11.0.0\debug\threading-multi\32.obj
      "..\..\libs\config\checks\architecture\32.cpp" -Fo"..\..\bin.v2\libs\config\checks\architecture\clang-win-11.0.0\debug\threading-multi\32.obj"    -TP /EHs /GR /Z7 /Od /Ob0 /W3 /MDd -c -DBOOST_ALL_NO_LIB=1 "-I..\.." 
```
and launching of `32.cpp` in the default editor.