### PR TITLE
Add default value for cxx and cxxflags options when the cxx toolset is specified

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -286,10 +286,10 @@ fi
 # we assume they meant $CXX and $CXXFLAGS.
 if test "${B2_TOOLSET}" = "cxx" ; then
     if test "${B2_CXX_OPT}" = "" ; then
-        B2_CXX_OPT=${CXX}
+        B2_CXX_OPT="${CXX}"
     fi
     if test "${B2_CXXFLAGS_OPT}" = "" ; then
-        B2_CXXFLAGS_OPT=${CXXFLAGS}
+        B2_CXXFLAGS_OPT="${CXXFLAGS}"
     fi
 fi
 

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -276,10 +276,21 @@ if test_true ${B2_HELP_OPT} ; then
     error_exit
 fi
 
-# If we have a CXX but no B2_TOLSET specified by the user we assume they meant
+# If we have a CXX but no B2_TOOLSET specified by the user we assume they meant
 # "cxx" as the toolset.
 if test "${B2_CXX_OPT}" != "" -a "${B2_TOOLSET}" = "" ; then
     B2_TOOLSET=cxx
+fi
+
+# If we have B2_TOOLSET=cxx but no B2_CXX_OPT nor B2_CXXFLAGS_OPT specified by the user
+# we assume they meant $CXX and $CXXFLAGS.
+if test "${B2_TOOLSET}" = "cxx" ; then
+    if test "${B2_CXX_OPT}" = "" ; then
+        B2_CXX_OPT=${CXX}
+    fi
+    if test "${B2_CXXFLAGS_OPT}" = "" ; then
+        B2_CXXFLAGS_OPT=${CXXFLAGS}
+    fi
 fi
 
 # Guess toolset, or toolset commands.


### PR DESCRIPTION
As discussed on [slack](https://cpplang.slack.com/archives/C27KZLB0X/p1619028622427200), this PR adds default values for `--cxx` and `--cxxflags` options for the `cxx`  toolset: 

```
--cxx=[$CXX]
--cxxflag=[$CXXFLAGS]
```

This allows to run `./bootstrap.sh --with-toolset=cxx` and get what I think is the expected behavior.