### PR TITLE
Avoid use of "local" in /bin/sh-based script

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -111,9 +111,7 @@ test_uname ()
 
 test_compiler ()
 {
-    local EXE="${B2_CXX_OPT:-$1}"
-    local CMD
-    local SETUP
+    EXE="${B2_CXX_OPT:-$1}"
     shift
     CMD="${EXE} $@ ${B2_CXXFLAGS_OPT:-}"
     SETUP=${B2_SETUP:-true}
@@ -123,7 +121,7 @@ test_compiler ()
     else
         ( ${SETUP} ; ${CMD} check_cxx11.cpp ) 1>/dev/null 2>/dev/null
     fi
-    local CHECK_RESULT=$?
+    CHECK_RESULT=$?
     if test_true ${CHECK_RESULT} ; then
         B2_CXX=${CMD}
     fi


### PR DESCRIPTION
Tried building Boost in Solaris 11.4 and got this:
```
+ ./bootstrap.sh --with-toolset=gcc
Building B2 engine..
./tools/build/src/engine/build.sh[114]: local: not found [No such file or directory]
./tools/build/src/engine/build.sh[115]: local: not found [No such file or directory]
./tools/build/src/engine/build.sh[116]: local: not found [No such file or directory]
./tools/build/src/engine/build.sh[126]: local: not found [No such file or directory]
./tools/build/src/engine/build.sh[40]: test: argument expected
B2_TOOLSET is gcc, but the 'gcc' command cannot be executed.
Make sure 'gcc' is in PATH, or use a different toolset.

Failed to build B2 build engine
```

Looks like `/bin/sh` on Solaris doesn't have extra `bash`/`ksh` features, and [`local` is not in POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html).

  Thank you for your contributions. Main development of B2 has moved to
  https://github.com/bfgroup/b2
