### PR TITLE
Declare the /python//numpy target to hold the include path (fixes #725)

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -1052,6 +1052,9 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
             ;
     }
 
+    # Declare the numpy target, which contains the NumPy include directory
+
+    alias numpy : : $(target-requirements) : : <include>$(.numpy-include) ;
 }
 
 # Conditional rule specification that will prevent building of a target


### PR DESCRIPTION
This declares a `/python//numpy` target in `python.jam` to hold the NumPy include path; the current practice of using a variable does not support more than one Python installation. See issue #725.