### PR TITLE
Remove unused mips revision

### DIFF
--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -262,7 +262,7 @@ def register_globals ():
         'power',
 
         # MIPS/SGI
-        'mips1',
+        'mips',
 
         # HP/PA-RISC
         'parisc',

--- a/src/tools/builtin.py
+++ b/src/tools/builtin.py
@@ -262,7 +262,7 @@ def register_globals ():
         'power',
 
         # MIPS/SGI
-        'mips1', 'mips2', 'mips3', 'mips4', 'mips32', 'mips32r2', 'mips64',
+        'mips1',
 
         # HP/PA-RISC
         'parisc',

--- a/src/tools/features/architecture-feature.jam
+++ b/src/tools/features/architecture-feature.jam
@@ -8,8 +8,7 @@ import feature ;
 #| tag::doc[]
 
 [[bbv2.builtin.features.architecture]]`architecture`::
-*Allowed values:* `x86`, `ia64`, `sparc`, `power`, `mips1`, `mips2`,
-`mips3`, `mips4`, `mips32`, `mips32r2`, `mips64`, `parisc`, `arm`,
+*Allowed values:* `x86`, `ia64`, `sparc`, `power`, `mips1`, `parisc`, `arm`,
 `s390x`, `combined`, `combined-x86-power`.
 +
 Specifies the general processor family to generate code for.
@@ -31,7 +30,7 @@ feature.feature architecture
         power
 
         # MIPS/SGI
-        mips1 mips2 mips3 mips4 mips32 mips32r2 mips64
+        mips1
 
         # HP/PA-RISC
         parisc

--- a/src/tools/features/architecture-feature.jam
+++ b/src/tools/features/architecture-feature.jam
@@ -8,7 +8,7 @@ import feature ;
 #| tag::doc[]
 
 [[bbv2.builtin.features.architecture]]`architecture`::
-*Allowed values:* `x86`, `ia64`, `sparc`, `power`, `mips1`, `parisc`, `arm`,
+*Allowed values:* `x86`, `ia64`, `sparc`, `power`, `mips`, `parisc`, `arm`,
 `s390x`, `combined`, `combined-x86-power`.
 +
 Specifies the general processor family to generate code for.
@@ -30,7 +30,7 @@ feature.feature architecture
         power
 
         # MIPS/SGI
-        mips1
+        mips
 
         # HP/PA-RISC
         parisc

--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -63,7 +63,7 @@ toolset.flags qcc QCC-TARGET-PLATFORM <architecture>arm/<address-model>64 : -Vgc
 
 # Combinations supported by QNX 6.5.0
 toolset.flags qcc QCC-TARGET-PLATFORM <architecture>power/<address-model>32 : -Vgcc_ntoppcbe ;
-toolset.flags qcc QCC-TARGET-PLATFORM <architecture>mips1/<address-model>32 : -Vgcc_ntomipsle ;
+toolset.flags qcc QCC-TARGET-PLATFORM <architecture>mips/<address-model>32 : -Vgcc_ntomipsle ;
 
 # There are also excluded alternatives (supported by QNX 6.5.0)
 # toolset.flags qcc QCC-TARGET-PLATFORM <architecture>arm/<address-model>32 : -Vgcc_ntoarmle ;

--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -68,7 +68,7 @@ toolset.flags qcc QCC-TARGET-PLATFORM <architecture>mips/<address-model>32 : -Vg
 # There are also excluded alternatives (supported by QNX 6.5.0)
 # toolset.flags qcc QCC-TARGET-PLATFORM <architecture>arm/<address-model>32 : -Vgcc_ntoarmle ;
 # toolset.flags qcc QCC-TARGET-PLATFORM <architecture>power/<address-model>32 : -Vgcc_ntoppcbespe ;
-# toolset.flags qcc QCC-TARGET-PLATFORM <architecture>mips1/<address-model>32 : -Vgcc_ntomipsbe ;
+# toolset.flags qcc QCC-TARGET-PLATFORM <architecture>mips/<address-model>32 : -Vgcc_ntomipsbe ;
 
 local rule check-target-platform
 {


### PR DESCRIPTION
There are several mips revision:
  'mips1', 'mips2', 'mips3', 'mips4', 'mips32', 'mips32r2', 'mips64'.
while in fact only mips1 is used, so remove other ones.
And, mips1 in fact is used for all MIPS revisions.

Then rename mips1 to mips.

