### PR TITLE
icpc (nor icpx) can build a fully static version of b2 on linux since…

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -327,6 +327,12 @@ case "${B2_TOOLSET}" in
         B2_CXXFLAGS_DEBUG="-O0 -g"
     ;;
 
+    intel-linux)
+        CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+        B2_CXXFLAGS_RELEASE="-O3"
+        B2_CXXFLAGS_DEBUG="-O0 -g -p"
+    ;;
+
     intel-*)
         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
         B2_CXXFLAGS_RELEASE="-O3 -s -static"


### PR DESCRIPTION
… libstdc++ does not usually exists on that platform.

  Thank you for your contributions. Main development of B2 has moved to
  https://github.com/bfgroup/b2
