### PR TITLE
Adding fixes to allows boost to be built for web assembly

### DIFF
--- a/src/tools/emscripten.jam
+++ b/src/tools/emscripten.jam
@@ -6,6 +6,7 @@
 import feature ;
 import os ;
 import toolset ;
+import generators ;
 import common ;
 import gcc ;
 import type ;
@@ -50,6 +51,9 @@ toolset.inherit-flags emscripten : gcc
         <debug-symbols>off <debug-symbols>on
         <rtti>off <rtti>on
         ;
+
+generators.override builtin.lib-generator : emscripten.prebuilt ;
+generators.override emscripten.searched-lib-generator : searched-lib-generator ;
 
 type.set-generated-target-suffix EXE : <toolset>emscripten : "js" ;
 type.set-generated-target-suffix OBJ : <toolset>emscripten : "bc" ;


### PR DESCRIPTION
PR to allow boost to be built for web assembly.

See https://github.com/boostorg/regex/issues/59#issuecomment-828707747

Without this you get the error message...

```
Error: ambiguity found when searching for best transformation
Trying to produce type 'SEARCHED_LIB' from:
Generators that succeeded:
 -  searched-lib-generator
 -  emscripten.searched-lib-generator
First generator produced:
 -  { %.no-action-psapi.SEARCHED_LIB }
Second generator produced:
 -  { %.no-action-psapi.SEARCHED_LIB }
 ```