### PR TITLE
support RISCV in property os

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -442,6 +442,15 @@
     #define OSPLAT "OSPLAT=PARISC"
 #endif
 
+#if defined( __riscv ) || \
+    defined( __riscv__ )
+  #if 64 == __riscv_xlen
+    #define OSPLAT "OSPLAT=RISCV64"
+  #elif _32 == _riscv_xlen
+    #define OSPLAT "OSPLAT=RISCV32"
+  #endif
+#endif
+
 #ifndef OSPLAT
     #define OSPLAT ""
 #endif


### PR DESCRIPTION
Check for RSICV preprocessor definitions in order to set OSPLAT appropriately.

  Thank you for your contributions. Main development of B2 has moved to
  https://github.com/bfgroup/b2
