### PR TITLE
support recent Intel compilers

### DIFF
--- a/src/tools/intel-linux.jam
+++ b/src/tools/intel-linux.jam
@@ -290,17 +290,17 @@ rule compile.c.pch ( targets * : sources * : properties * )
 #
 actions compile.c++.pch
 {
-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
+    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 actions compile.fortran
 {
-    LD_LIBRARY_PATH="$(RUN_PATH)" "ifort" -c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+    LD_LIBRARY_PATH="$(RUN_PATH)" "ifx" -c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 actions compile.c.pch
 {
-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
+    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 rule link ( targets * : sources * : properties * )


### PR DESCRIPTION
breaks for older, non-LLVM compilers. But oneAPI is around for quite some time and better to break old versions that the current versions.

This solves
- "icpx: error: unsupported argument 'h-create' to option '-pc'"
- command not found: ifort

I don't think that Fortran is used at all

Thank you for your contributions. Main development of B2 has moved to
  https://github.com/bfgroup/b2
